### PR TITLE
Parameter mapping: Add option to ignore time-point specific noiseParameters

### DIFF
--- a/petab/lint.py
+++ b/petab/lint.py
@@ -558,10 +558,10 @@ def measurement_table_has_timepoint_specific_mappings(
             PEtab measurement table
 
         allow_scalar_numeric_noise_parameters:
-            ignore scalar numeric assignments to noiseParamater placeholders
+            ignore scalar numeric assignments to noiseParameter placeholders
 
         allow_scalar_numeric_observable_parameters:
-            ignore scalar numeric assignments to observableParamater
+            ignore scalar numeric assignments to observableParameter
             placeholders
 
     Returns:
@@ -601,7 +601,6 @@ def measurement_table_has_timepoint_specific_mappings(
          SIMULATION_CONDITION_ID,
          PREEQUILIBRATION_CONDITION_ID])
     grouped_df2 = measurement_df.groupby(grouping_cols)
-
     # data frame has timepoint specific overrides if grouping by noise
     # parameters and observable parameters in addition to observable,
     # condition and preeq id yields more groups

--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -165,7 +165,7 @@ def _map_condition(packed_args):
     (condition, measurement_df, condition_df, parameter_df, sbml_model,
      simulation_parameters, warn_unmapped, scaled_parameters,
      fill_fixed_parameters,
-     allow_scalar_timepoint_specific_numeric_noise_parameters) = packed_args
+     allow_timepoint_specific_numeric_noise_parameters) = packed_args
 
     cur_measurement_df = measurements.get_rows_for_condition(
         measurement_df, condition)

--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -42,7 +42,7 @@ def get_optimization_to_simulation_parameter_mapping(
         warn_unmapped: Optional[bool] = True,
         scaled_parameters: bool = False,
         fill_fixed_parameters: bool = True,
-        allow_scalar_timepoint_specific_numeric_noise_parameters: bool = False
+        allow_timepoint_specific_numeric_noise_parameters: bool = False
 ) -> List[ParMappingDictQuadruple]:
     """
     Create list of mapping dicts from PEtab-problem to SBML parameters.
@@ -66,7 +66,7 @@ def get_optimization_to_simulation_parameter_mapping(
         fill_fixed_parameters:
             Whether to fill in nominal values for fixed parameters
             (estimate=0 in parameters table).
-        allow_scalar_timepoint_specific_numeric_noise_parameters:
+        allow_timepoint_specific_numeric_noise_parameters:
             Mapping of timepoint-specific parameters overrides is generally
             not supported. If this option is set to True, this function will
             not fail in case of timepoint-specific fixed noise parameters,
@@ -94,8 +94,8 @@ def get_optimization_to_simulation_parameter_mapping(
     # Ensure inputs are okay
     _perform_mapping_checks(
         measurement_df,
-        allow_scalar_timepoint_specific_numeric_noise_parameters=
-        allow_scalar_timepoint_specific_numeric_noise_parameters)
+        allow_timepoint_specific_numeric_noise_parameters=  # noqa: E251,E501
+        allow_timepoint_specific_numeric_noise_parameters)
 
     if simulation_conditions is None:
         simulation_conditions = measurements.get_simulation_conditions(
@@ -121,7 +121,7 @@ def get_optimization_to_simulation_parameter_mapping(
                 simulation_conditions, measurement_df, condition_df,
                 parameter_df, sbml_model, simulation_parameters, warn_unmapped,
                 scaled_parameters, fill_fixed_parameters,
-                allow_scalar_timepoint_specific_numeric_noise_parameters))
+                allow_timepoint_specific_numeric_noise_parameters))
         return list(mapping)
 
     # Run multi-threaded
@@ -133,7 +133,7 @@ def get_optimization_to_simulation_parameter_mapping(
                 simulation_conditions, measurement_df, condition_df,
                 parameter_df, sbml_model, simulation_parameters, warn_unmapped,
                 scaled_parameters, fill_fixed_parameters,
-                allow_scalar_timepoint_specific_numeric_noise_parameters))
+                allow_timepoint_specific_numeric_noise_parameters))
     return list(mapping)
 
 
@@ -147,14 +147,14 @@ def _map_condition_arg_packer(
         warn_unmapped,
         scaled_parameters,
         fill_fixed_parameters,
-        allow_scalar_timepoint_specific_numeric_noise_parameters
+        allow_timepoint_specific_numeric_noise_parameters
 ):
     """Helper function to pack extra arguments for _map_condition"""
     for _, condition in simulation_conditions.iterrows():
         yield(condition, measurement_df, condition_df, parameter_df,
               sbml_model, simulation_parameters, warn_unmapped,
               scaled_parameters, fill_fixed_parameters,
-              allow_scalar_timepoint_specific_numeric_noise_parameters)
+              allow_timepoint_specific_numeric_noise_parameters)
 
 
 def _map_condition(packed_args):
@@ -187,8 +187,8 @@ def _map_condition(packed_args):
             warn_unmapped=warn_unmapped,
             scaled_parameters=scaled_parameters,
             fill_fixed_parameters=fill_fixed_parameters,
-            allow_scalar_timepoint_specific_numeric_noise_parameters=
-            allow_scalar_timepoint_specific_numeric_noise_parameters
+            allow_timepoint_specific_numeric_noise_parameters=  # noqa: E251,E501
+            allow_timepoint_specific_numeric_noise_parameters
         )
 
     par_map_sim, scale_map_sim = get_parameter_mapping_for_condition(
@@ -202,8 +202,8 @@ def _map_condition(packed_args):
         warn_unmapped=warn_unmapped,
         scaled_parameters=scaled_parameters,
         fill_fixed_parameters=fill_fixed_parameters,
-        allow_scalar_timepoint_specific_numeric_noise_parameters=
-        allow_scalar_timepoint_specific_numeric_noise_parameters
+        allow_timepoint_specific_numeric_noise_parameters=  # noqa: E251,E501
+        allow_timepoint_specific_numeric_noise_parameters
     )
 
     return par_map_preeq, par_map_sim, scale_map_preeq, scale_map_sim
@@ -220,7 +220,7 @@ def get_parameter_mapping_for_condition(
         warn_unmapped: bool = True,
         scaled_parameters: bool = False,
         fill_fixed_parameters: bool = True,
-        allow_scalar_timepoint_specific_numeric_noise_parameters: bool = False,
+        allow_timepoint_specific_numeric_noise_parameters: bool = False,
 ) -> Tuple[ParMappingDict, ScaleMappingDict]:
     """
     Create dictionary of parameter value and parameter scale mappings from
@@ -251,7 +251,7 @@ def get_parameter_mapping_for_condition(
         fill_fixed_parameters:
             Whether to fill in nominal values for fixed parameters
             (estimate=0 in parameters table).
-        allow_scalar_timepoint_specific_numeric_noise_parameters:
+        allow_timepoint_specific_numeric_noise_parameters:
             Mapping of timepoint-specific parameters overrides is generally
             not supported. If this option is set to True, this function will
             not fail in case of timepoint-specific fixed noise parameters,
@@ -268,8 +268,8 @@ def get_parameter_mapping_for_condition(
     """
     _perform_mapping_checks(
         cur_measurement_df,
-        allow_scalar_timepoint_specific_numeric_noise_parameters=
-        allow_scalar_timepoint_specific_numeric_noise_parameters)
+        allow_timepoint_specific_numeric_noise_parameters=  # noqa: E251,E501
+        allow_timepoint_specific_numeric_noise_parameters)
 
     if simulation_parameters is None:
         simulation_parameters = sbml.get_model_parameters(sbml_model,
@@ -468,15 +468,15 @@ def _apply_parameter_table(par_mapping: ParMappingDict,
 
 def _perform_mapping_checks(
         measurement_df: pd.DataFrame,
-        allow_scalar_timepoint_specific_numeric_noise_parameters: bool = False
+        allow_timepoint_specific_numeric_noise_parameters: bool = False
 ) -> None:
     """Check for PEtab features which we can't account for during parameter
     mapping."""
 
     if lint.measurement_table_has_timepoint_specific_mappings(
             measurement_df,
-            allow_scalar_numeric_noise_parameters=
-            allow_scalar_timepoint_specific_numeric_noise_parameters):
+            allow_scalar_numeric_noise_parameters=  # noqa: E251,E501
+            allow_timepoint_specific_numeric_noise_parameters):
         # we could allow that for floats, since they don't matter in this
         # function and would be simply ignored
         raise ValueError(

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -611,7 +611,7 @@ class Problem:
             self,
             warn_unmapped: bool = True,
             scaled_parameters: bool = False,
-            allow_scalar_timepoint_specific_numeric_noise_parameters:
+            allow_timepoint_specific_numeric_noise_parameters:
             bool = False,
     ):
         """
@@ -626,9 +626,9 @@ class Problem:
                 self.sbml_model,
                 warn_unmapped=warn_unmapped,
                 scaled_parameters=scaled_parameters,
-                allow_scalar_timepoint_specific_numeric_noise_parameters=
-                allow_scalar_timepoint_specific_numeric_noise_parameters
-        )
+                allow_timepoint_specific_numeric_noise_parameters=  # noqa: E251,E501
+                allow_timepoint_specific_numeric_noise_parameters
+            )
 
     def create_parameter_df(self, *args, **kwargs):
         """Create a new PEtab parameter table

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -608,7 +608,12 @@ class Problem:
         return measurements.get_simulation_conditions(self.measurement_df)
 
     def get_optimization_to_simulation_parameter_mapping(
-            self, warn_unmapped: bool = True, scaled_parameters: bool = False):
+            self,
+            warn_unmapped: bool = True,
+            scaled_parameters: bool = False,
+            allow_scalar_timepoint_specific_numeric_noise_parameters:
+            bool = False,
+    ):
         """
         See get_simulation_to_optimization_parameter_mapping.
         """
@@ -620,7 +625,10 @@ class Problem:
                 self.observable_df,
                 self.sbml_model,
                 warn_unmapped=warn_unmapped,
-                scaled_parameters=scaled_parameters)
+                scaled_parameters=scaled_parameters,
+                allow_scalar_timepoint_specific_numeric_noise_parameters=
+                allow_scalar_timepoint_specific_numeric_noise_parameters
+        )
 
     def create_parameter_df(self, *args, **kwargs):
         """Create a new PEtab parameter table


### PR DESCRIPTION
... in case those are fixed values and noiseFormula consists only of one single parameter.