### PR TITLE
Optional relative paths in generated YAML

### DIFF
--- a/petab/problem.py
+++ b/petab/problem.py
@@ -272,7 +272,7 @@ class Problem:
                  visualization_file: Optional[str] = None,
                  observable_file: Optional[str] = None,
                  yaml_file: Optional[str] = None,
-                 yaml_centric: bool = True,) -> None:
+                 relative_paths: bool = True,) -> None:
         """
         Write PEtab tables to files for this problem
 
@@ -290,9 +290,9 @@ class Problem:
             visualization_file: Visualization table destination
             observable_file: Observables table destination
             yaml_file: YAML file destination
-            yaml_centric: whether all paths in the YAML file should be relative
-            to the location of the YAML file. If `False`, then paths are left
-            unchanged.
+            relative_paths: whether all paths in the YAML file should be
+            relative to the location of the YAML file. If `False`, then paths
+            are left unchanged.
 
         Raises:
             ValueError:
@@ -349,7 +349,7 @@ class Problem:
                                      measurement_file, parameter_file,
                                      observable_file, yaml_file,
                                      visualization_file,
-                                     yaml_centric=yaml_centric,)
+                                     relative_paths=relative_paths,)
 
     def get_optimization_parameters(self):
         """

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -290,6 +290,8 @@ class Problem:
             visualization_file: Visualization table destination
             observable_file: Observables table destination
             yaml_file: YAML file destination
+            yaml_centric: whether all paths in the YAML file should be relative
+            to the location of the YAML file
 
         Raises:
             ValueError:

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -271,7 +271,8 @@ class Problem:
                  parameter_file: Optional[str] = None,
                  visualization_file: Optional[str] = None,
                  observable_file: Optional[str] = None,
-                 yaml_file: Optional[str] = None) -> None:
+                 yaml_file: Optional[str] = None,
+                 yaml_centric: bool = True,) -> None:
         """
         Write PEtab tables to files for this problem
 
@@ -344,7 +345,8 @@ class Problem:
             yaml.create_problem_yaml(sbml_file, condition_file,
                                      measurement_file, parameter_file,
                                      observable_file, yaml_file,
-                                     visualization_file)
+                                     visualization_file,
+                                     yaml_centric=yaml_centric,)
 
     def get_optimization_parameters(self):
         """

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -291,7 +291,8 @@ class Problem:
             observable_file: Observables table destination
             yaml_file: YAML file destination
             yaml_centric: whether all paths in the YAML file should be relative
-            to the location of the YAML file
+            to the location of the YAML file. If `False`, then paths are left
+            unchanged.
 
         Raises:
             ValueError:

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -181,7 +181,7 @@ def create_problem_yaml(
         observable_files: Union[str, List[str]],
         yaml_file: str,
         visualization_files: Optional[Union[str, List[str]]] = None,
-        yaml_centric: bool = False,
+        relative_paths: bool = True,
 ) -> None:
     """
     Create and write default YAML file for a single PEtab problem
@@ -195,8 +195,8 @@ def create_problem_yaml(
         yaml_file: Path to which YAML file should be written
         visualization_files: Optional Path to visualization file or list of
         such
-        yaml_centric: whether all paths in the YAML file should be relative to
-        the location of the YAML file. If `False`, then paths are left
+        relative_paths: whether all paths in the YAML file should be relative
+        to the location of the YAML file. If `False`, then paths are left
         unchanged.
     """
     if isinstance(sbml_files, str):
@@ -210,7 +210,7 @@ def create_problem_yaml(
     if isinstance(visualization_files, str):
         visualization_files = [visualization_files]
 
-    if yaml_centric:
+    if relative_paths:
         yaml_file_dir = Path(yaml_file).parent
 
         def get_rel_to_yaml(paths: List[str]):

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -213,7 +213,9 @@ def create_problem_yaml(
     if relative_paths:
         yaml_file_dir = Path(yaml_file).parent
 
-        def get_rel_to_yaml(paths: List[str]):
+        def get_rel_to_yaml(paths: Union[List[str], None]):
+            if paths is None:
+                return paths
             return [
                 os.path.relpath(path, start=yaml_file_dir)
                 for path in paths

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -196,7 +196,8 @@ def create_problem_yaml(
         visualization_files: Optional Path to visualization file or list of
         such
         yaml_centric: whether all paths in the YAML file should be relative to
-        the location of the YAML file
+        the location of the YAML file. If `False`, then paths are left
+        unchanged.
     """
     if isinstance(sbml_files, str):
         sbml_files = [sbml_files]
@@ -215,13 +216,13 @@ def create_problem_yaml(
         def get_rel_to_yaml(paths: List[str]):
             return [os.path.relpath(path, start=yaml_file_dir) for path in paths]
 
-        sbml_files = get_relative_paths(sbml_files)
-        condition_files = get_relative_paths(condition_files)
-        measurement_files = get_relative_paths(measurement_files)
-        observable_files = get_relative_paths(observable_files)
-        visualization_files = get_relative_paths(visualization_files)
+        sbml_files = get_rel_to_yaml(sbml_files)
+        condition_files = get_rel_to_yaml(condition_files)
+        measurement_files = get_rel_to_yaml(measurement_files)
+        observable_files = get_rel_to_yaml(observable_files)
+        visualization_files = get_rel_to_yaml(visualization_files)
 
-        parameter_file = get_relative_paths([parameter_file])[0]
+        parameter_file = get_rel_to_yaml([parameter_file])[0]
 
     problem_dic = {CONDITION_FILES: condition_files,
                    MEASUREMENT_FILES: measurement_files,

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -214,7 +214,10 @@ def create_problem_yaml(
         yaml_file_dir = Path(yaml_file).parent
 
         def get_rel_to_yaml(paths: List[str]):
-            return [os.path.relpath(path, start=yaml_file_dir) for path in paths]
+            return [
+                os.path.relpath(path, start=yaml_file_dir)
+                for path in paths
+            ]
 
         sbml_files = get_rel_to_yaml(sbml_files)
         condition_files = get_rel_to_yaml(condition_files)

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -212,8 +212,8 @@ def create_problem_yaml(
     if yaml_centric:
         yaml_file_dir = Path(yaml_file).parent
 
-        def get_relative_paths(paths, start=yaml_file_dir):
-            return [os.path.relpath(path, start=start) for path in paths]
+        def get_rel_to_yaml(paths: List[str]):
+            return [os.path.relpath(path, start=yaml_file_dir) for path in paths]
 
         sbml_files = get_relative_paths(sbml_files)
         condition_files = get_relative_paths(condition_files)

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -1,6 +1,7 @@
 """Code regarding the PEtab YAML config files"""
 
 import os
+from pathlib import Path
 from typing import Any, Dict, Union, Optional, List
 
 import jsonschema
@@ -172,14 +173,16 @@ def write_yaml(yaml_config: Dict[str, Any], filename: str) -> None:
                   sort_keys=False)
 
 
-def create_problem_yaml(sbml_files: Union[str, List[str]],
-                        condition_files: Union[str, List[str]],
-                        measurement_files: Union[str, List[str]],
-                        parameter_file: str,
-                        observable_files: Union[str, List[str]],
-                        yaml_file: str,
-                        visualization_files: Optional[Union[str, List[str]]]
-                        = None) -> None:
+def create_problem_yaml(
+        sbml_files: Union[str, List[str]],
+        condition_files: Union[str, List[str]],
+        measurement_files: Union[str, List[str]],
+        parameter_file: str,
+        observable_files: Union[str, List[str]],
+        yaml_file: str,
+        visualization_files: Optional[Union[str, List[str]]] = None,
+        yaml_centric: bool = False,
+) -> None:
     """
     Create and write default YAML file for a single PEtab problem
 
@@ -203,6 +206,20 @@ def create_problem_yaml(sbml_files: Union[str, List[str]],
         observable_files = [observable_files]
     if isinstance(visualization_files, str):
         visualization_files = [visualization_files]
+
+    if yaml_centric:
+        yaml_file_dir = Path(yaml_file).parent
+
+        def get_relative_paths(paths, start=yaml_file_dir):
+            return [os.path.relpath(path, start=start) for path in paths]
+
+        sbml_files = get_relative_paths(sbml_files)
+        condition_files = get_relative_paths(condition_files)
+        measurement_files = get_relative_paths(measurement_files)
+        observable_files = get_relative_paths(observable_files)
+        visualization_files = get_relative_paths(visualization_files)
+
+        parameter_file = get_relative_paths([parameter_file])[0]
 
     problem_dic = {CONDITION_FILES: condition_files,
                    MEASUREMENT_FILES: measurement_files,

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -195,6 +195,8 @@ def create_problem_yaml(
         yaml_file: Path to which YAML file should be written
         visualization_files: Optional Path to visualization file or list of
         such
+        yaml_centric: whether all paths in the YAML file should be relative to
+        the location of the YAML file
     """
     if isinstance(sbml_files, str):
         sbml_files = [sbml_files]


### PR DESCRIPTION
- feel free to suggest a better name than `yaml_centric`
- not sure if it should default to relative paths when calling `petab.Problem.to_files` and/or `petab.yaml.create_problem_yaml` (currently only the former)