### PR TITLE
Fix unreachable TypeError in petab.parameter_mapping.apply_overrides_…

### DIFF
--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -360,14 +360,7 @@ def _apply_overrides_for_observable(
     """
     for i, override in enumerate(overrides):
         overridee_id = f'{override_type}Parameter{i+1}_{observable_id}'
-        try:
-            mapping[overridee_id] = override
-        except KeyError as e:
-            raise TypeError(f'Cannot override {override_type} parameter '
-                            f'{overridee_id} for observable {observable_id}.'
-                            f'Ensure there exists an {override_type} '
-                            'definition containing the correct number of '
-                            'placeholder parameters.') from e
+        mapping[overridee_id] = override
 
 
 def _apply_condition_parameters(par_mapping: ParMappingDict,


### PR DESCRIPTION
…for_observable (fixes #59)

Revert "More informative error messages in case of wrongly set observable and noise parameters (Closes PEtab-dev/PEtab#118) (PEtab-dev/PEtab#155)"

This reverts commit 8fab85e2b581ff501ee0a5595faa4d28543c0257.