### PR TITLE
petablint: require overriding of observable/noise placeholder parameters

### DIFF
--- a/petab/measurements.py
+++ b/petab/measurements.py
@@ -289,13 +289,13 @@ def assert_overrides_match_parameter_count(
         actual = len(split_parameter_replacement_list(
             row.get(OBSERVABLE_PARAMETERS, None)))
         # No overrides are also allowed
-        if actual not in [0, expected]:
+        if actual != expected:
             formula = observable_df.loc[row[OBSERVABLE_ID], OBSERVABLE_FORMULA]
             raise AssertionError(
                 f'Mismatch of observable parameter overrides for '
                 f'{row[OBSERVABLE_ID]} ({formula})'
                 f'in:\n{row}\n'
-                f'Expected 0 or {expected} but got {actual}')
+                f'Expected {expected} but got {actual}')
 
         # check noise parameters
         replacements = split_parameter_replacement_list(
@@ -304,10 +304,10 @@ def assert_overrides_match_parameter_count(
             expected = noise_parameters_count[row[OBSERVABLE_ID]]
 
             # No overrides are also allowed
-            if not (len(replacements) == 0 or len(replacements) == expected):
+            if len(replacements) != expected:
                 raise AssertionError(
                     f'Mismatch of noise parameter overrides in:\n{row}\n'
-                    f'Expected 0 or {expected} but got {actual}')
+                    f'Expected {expected} but got {actual}')
         except KeyError:
             # no overrides defined, but a numerical sigma can be provided
             # anyways

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -122,38 +122,61 @@ def test_assert_overrides_match_parameter_count():
         SIMULATION_CONDITION_ID: ['condition1', 'condition1'],
         PREEQUILIBRATION_CONDITION_ID: ['', ''],
         TIME: [1.0, 2.0],
-        OBSERVABLE_PARAMETERS: ['', ''],
-        NOISE_PARAMETERS: ['', '']
+        OBSERVABLE_PARAMETERS: ['', 'override1;override2'],
+        NOISE_PARAMETERS: ['noiseParOverride', '']
     })
 
-    # No overrides
+    # valid
     petab.assert_overrides_match_parameter_count(
         measurement_df_orig, observable_df)
 
-    # Sigma override
+    # 0 noise parameters given, 1 expected
     measurement_df = measurement_df_orig.copy()
-    measurement_df.loc[0, NOISE_PARAMETERS] = 'noiseParOverride'
-    petab.assert_overrides_match_parameter_count(
-        measurement_df, observable_df)
+    measurement_df.loc[0, NOISE_PARAMETERS] = ''
+    with pytest.raises(AssertionError):
+        petab.assert_overrides_match_parameter_count(
+            measurement_df, observable_df)
 
+    # 2 noise parameters given, 1 expected
+    measurement_df = measurement_df_orig.copy()
     measurement_df.loc[0, NOISE_PARAMETERS] = 'noiseParOverride;oneTooMuch'
     with pytest.raises(AssertionError):
         petab.assert_overrides_match_parameter_count(
             measurement_df, observable_df)
 
-    measurement_df.loc[0, NOISE_PARAMETERS] = 'noiseParOverride'
+    # 1 noise parameter given, 0 allowed
+    measurement_df = measurement_df_orig.copy()
     measurement_df.loc[1, NOISE_PARAMETERS] = 'oneTooMuch'
     with pytest.raises(AssertionError):
         petab.assert_overrides_match_parameter_count(
             measurement_df, observable_df)
 
-    # Observable override
+    # 0 observable parameters given, 2 expected
     measurement_df = measurement_df_orig.copy()
-    measurement_df.loc[1, OBSERVABLE_PARAMETERS] = 'override1;override2'
-    petab.assert_overrides_match_parameter_count(
-        measurement_df, observable_df)
+    measurement_df.loc[1, OBSERVABLE_PARAMETERS] = ''
+    with pytest.raises(AssertionError):
+        petab.assert_overrides_match_parameter_count(
+            measurement_df, observable_df)
 
+    # 1 observable parameters given, 2 expected
+    measurement_df = measurement_df_orig.copy()
     measurement_df.loc[1, OBSERVABLE_PARAMETERS] = 'oneMissing'
+    with pytest.raises(AssertionError):
+        petab.assert_overrides_match_parameter_count(
+            measurement_df, observable_df)
+
+    # 3 observable parameters given, 2 expected
+    measurement_df = measurement_df_orig.copy()
+    measurement_df.loc[1, OBSERVABLE_PARAMETERS] = \
+        'override1;override2;oneTooMuch'
+    with pytest.raises(AssertionError):
+        petab.assert_overrides_match_parameter_count(
+            measurement_df, observable_df)
+
+    # 1 observable parameters given, 0 expected
+    measurement_df = measurement_df_orig.copy()
+    measurement_df.loc[0, OBSERVABLE_PARAMETERS] = \
+        'oneTooMuch'
     with pytest.raises(AssertionError):
         petab.assert_overrides_match_parameter_count(
             measurement_df, observable_df)


### PR DESCRIPTION
So far it was allowed to not specify overrides for observable/noise parameter placeholders. Not sure why that was the case, as it is explicitly disallowed in the (current) PEtab specification.

Fixes #63