### PR TITLE
Convenience method to quickly output PEtab problem to files

### DIFF
--- a/petab/problem.py
+++ b/petab/problem.py
@@ -267,7 +267,7 @@ class Problem:
 
     def to_files_generic(
         self,
-        prefix_path: Optional[Union[str, Path]] = None,
+        prefix_path: Union[str, Path],
     ) -> None:
         """Save a PEtab problem to generic file names.
 

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -1,12 +1,13 @@
 """PEtab Problem class"""
 
 import os
+from pathlib import Path
 import tempfile
+from typing import Dict, Iterable, List, Optional, Union
 from warnings import warn
 
 import pandas as pd
 import libsbml
-from typing import Optional, List, Union, Dict, Iterable
 from . import (parameter_mapping, measurements, conditions, parameters,
                sampling, sbml, yaml, core, observables, format_version)
 from .C import *  # noqa: F403
@@ -264,6 +265,47 @@ class Problem:
 
         return problem
 
+    def to_files_generic(
+        self,
+        prefix_path: Optional[Union[str, Path]] = None,
+    ) -> None:
+        """Save a PEtab problem to generic file names.
+
+        The PEtab problem YAML file is always created. PEtab data files are
+        only created if the PEtab problem contains corresponding data (e.g. a
+        PEtab visualization TSV file is only created if the PEtab problem has
+        one).
+
+        Arguments:
+            prefix_path: Specify a prefix to all paths, to avoid specifying the
+            prefix for all paths individually. NB: the prefix is added to paths
+            before `relative_paths` is handled.
+
+        Returns:
+            The path to the PEtab problem YAML file.
+        """
+        filenames = {}
+        for table_name in [
+            'condition',
+            'measurement',
+            'parameter',
+            'observable',
+            'visualization',
+        ]:
+            if getattr(self, f'{table_name}_df') is not None:
+                filenames[f'{table_name}_file'] = f'{table_name}s.tsv'
+
+        if self.sbml_document is not None:
+            filenames['sbml_file'] = 'model.xml'
+
+        filenames['yaml_file'] = 'problem.yaml'
+
+        self.to_files(**filenames, prefix_path=prefix_path)
+
+        if prefix_path is None:
+            return filenames['yaml_file']
+        return str(prefix_path / filenames['yaml_file'])
+
     def to_files(self,
                  sbml_file: Optional[str] = None,
                  condition_file: Optional[str] = None,
@@ -272,6 +314,7 @@ class Problem:
                  visualization_file: Optional[str] = None,
                  observable_file: Optional[str] = None,
                  yaml_file: Optional[str] = None,
+                 prefix_path: Optional[Union[str, Path]] = None,
                  relative_paths: bool = True,) -> None:
         """
         Write PEtab tables to files for this problem
@@ -290,6 +333,9 @@ class Problem:
             visualization_file: Visualization table destination
             observable_file: Observables table destination
             yaml_file: YAML file destination
+            prefix_path: Specify a prefix to all paths, to avoid specifying the
+            prefix for all paths individually. NB: the prefix is added to paths
+            before `relative_paths` is handled.
             relative_paths: whether all paths in the YAML file should be
             relative to the location of the YAML file. If `False`, then paths
             are left unchanged.
@@ -298,6 +344,21 @@ class Problem:
             ValueError:
                 If a destination was provided for a non-existing entity.
         """
+        if prefix_path is not None:
+            prefix_path = Path(prefix_path)
+
+            def add_prefix(path0: Union[None, str, Path]) -> str:
+                if path0 is None:
+                    return path0
+                return str(prefix_path / path0)
+
+            sbml_file = add_prefix(sbml_file)
+            condition_file = add_prefix(condition_file)
+            measurement_file = add_prefix(measurement_file)
+            parameter_file = add_prefix(parameter_file)
+            observable_file = add_prefix(observable_file)
+            visualization_file = add_prefix(visualization_file)
+            yaml_file = add_prefix(yaml_file)
 
         if sbml_file:
             if self.sbml_document is not None:

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -284,6 +284,10 @@ class Problem:
         Returns:
             The path to the PEtab problem YAML file.
         """
+        prefix_path = Path(prefix_path)
+
+        # Generate generic filenames for data tables in the PEtab problem that
+        # contain data.
         filenames = {}
         for table_name in [
             'condition',

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -1,6 +1,7 @@
 """PEtab Problem class"""
 
 import os
+# Renamed to `Path_` to avoid unknown error during Sphinx doc build
 from pathlib import Path as Path_
 import tempfile
 from typing import Dict, Iterable, List, Optional, Union

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -279,7 +279,8 @@ class Problem:
         Arguments:
             prefix_path: Specify a prefix to all paths, to avoid specifying the
             prefix for all paths individually. NB: the prefix is added to paths
-            before `relative_paths` is handled.
+            before `relative_paths` is handled downstream in
+            `petab.yaml.create_problem_yaml`.
 
         Returns:
             The path to the PEtab problem YAML file.

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -1,7 +1,7 @@
 """PEtab Problem class"""
 
 import os
-from pathlib import Path
+from pathlib import Path as Path_
 import tempfile
 from typing import Dict, Iterable, List, Optional, Union
 from warnings import warn
@@ -267,7 +267,7 @@ class Problem:
 
     def to_files_generic(
         self,
-        prefix_path: Union[str, Path],
+        prefix_path: Union[str, Path_],
     ) -> None:
         """Save a PEtab problem to generic file names.
 
@@ -285,7 +285,7 @@ class Problem:
         Returns:
             The path to the PEtab problem YAML file.
         """
-        prefix_path = Path(prefix_path)
+        prefix_path = Path_(prefix_path)
 
         # Generate generic filenames for data tables in the PEtab problem that
         # contain data.
@@ -319,7 +319,7 @@ class Problem:
                  visualization_file: Optional[str] = None,
                  observable_file: Optional[str] = None,
                  yaml_file: Optional[str] = None,
-                 prefix_path: Optional[Union[str, Path]] = None,
+                 prefix_path: Optional[Union[str, Path_]] = None,
                  relative_paths: bool = True,) -> None:
         """
         Write PEtab tables to files for this problem
@@ -350,9 +350,9 @@ class Problem:
                 If a destination was provided for a non-existing entity.
         """
         if prefix_path is not None:
-            prefix_path = Path(prefix_path)
+            prefix_path = Path_(prefix_path)
 
-            def add_prefix(path0: Union[None, str, Path]) -> str:
+            def add_prefix(path0: Union[None, str, Path_]) -> str:
                 if path0 is None:
                     return path0
                 return str(prefix_path / path0)


### PR DESCRIPTION
Usage example for `petab.Problem.to_files_generic`:
```python
petab_problem_custom = petab.Problem.from_yaml(...)
petab_problem_custom.condition_df = ...

petab_yaml = petab_problem_custom.to_files_generic('my/output/path')
petab_problem = petab.Problem.from_yaml(petab_yaml)
```

Useful for applications involving many PEtab problems that are generated as customisations of some original PEtab problem.

Could rename to e.g. `to_folder`

---
Usage example for the new argument `prefix_path` in `petab.Problem.to_files`:
```python
petab_problem.to_files(
    sbml_file='model.xml',
    condition_file='conditions.tsv',
    measurement_file='measurements.tsv',
    parameter_file='parameters.tsv',
    observable_file='observables.tsv',
    visualization_file='visualizations.tsv',
    yaml_file='problem.yaml',
    prefix_path='my/output/path',
)
```
Old usage would be:
```python
petab_problem.to_files(
    sbml_file='my/output/path/model.xml',
    condition_file='my/output/path/conditions.tsv',
    measurement_file='my/output/path/measurements.tsv',
    parameter_file='my/output/path/parameters.tsv',
    observable_file='my/output/path/observables.tsv',
    visualization_file='my/output/path/visualizations.tsv',
    yaml_file='my/output/path/problem.yaml',
)
```