### PR TITLE
Ensure measurements are numeric and not null with linter

### DIFF
--- a/petab/lint.py
+++ b/petab/lint.py
@@ -943,16 +943,16 @@ def assert_measurements_numeric(
         AssertionError:
             Some measurement are not numeric.
     """
+    not_null_measurement_values = measurement_df[MEASUREMENT].dropna()
     all_measurements_are_numeric = (
-        pd.to_numeric(measurement_df[MEASUREMENT].dropna(), errors='coerce')
+        pd.to_numeric(not_null_measurement_values, errors='coerce')
         .notnull()
         .all()
     )
     if not all_measurements_are_numeric:
         raise AssertionError(
-            'Some values in the `petab.C.MEASUREMENT` column of the '
-            'PEtab measurements table are not numeric. This may be due to '
-            'null (missing) values.'
+            'Some values in the `petab.C.MEASUREMENT` column of the PEtab '
+            'measurements table are not numeric.'
         )
 
 

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -922,7 +922,7 @@ def assert_measurements_not_null(
 
     Raises:
         AssertionError:
-            Some measurement(s) are null (missing).
+            Some measurement value(s) are null (missing).
     """
     if measurement_df[MEASUREMENT].isnull().any():
         raise AssertionError('Some measurement(s) are null (missing).')
@@ -941,7 +941,7 @@ def assert_measurements_numeric(
 
     Raises:
         AssertionError:
-            Some measurement are not numeric.
+            Some measurement value(s) are not numeric.
     """
     not_null_measurement_values = measurement_df[MEASUREMENT].dropna()
     all_measurements_are_numeric = (


### PR DESCRIPTION
A benchmark model was passing the linter despite having null measurement values (see https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab/pull/129).