### PR TITLE
allow zero bounds for log parameters

### DIFF
--- a/petab/lint.py
+++ b/petab/lint.py
@@ -466,7 +466,7 @@ def check_parameter_bounds(parameter_df: pd.DataFrame) -> None:
                 raise AssertionError(
                     f"{LOWER_BOUND} greater than {UPPER_BOUND} for "
                     f"{PARAMETER_ID} {row.name}.")
-            if (row[LOWER_BOUND] <= 0.0 or row[UPPER_BOUND] < 0.0) \
+            if (row[LOWER_BOUND] < 0.0 or row[UPPER_BOUND] < 0.0) \
                     and row[PARAMETER_SCALE] in [LOG, LOG10]:
                 raise AssertionError(
                     f"Bounds for {row[PARAMETER_SCALE]} scaled parameter "


### PR DESCRIPTION
if there is no finiteness check for upper bound, I don't see why we should prevent lower bound 0 for log scale parameter, it convenient for specifying unbounded parameters after all.