### PR TITLE
GHA: Fix caching

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -27,9 +27,9 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ hashFiles('**/.ci_pip_reqs.txt') }}-${{ hashFiles('**/setup.py') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/.ci_pip_reqs.txt') }}-${{ hashFiles('**/setup.py') }}
         restore-keys: |
-          ${{ runner.os }}-
+          ${{ runner.os }}-${{ matrix.python-version }}-
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Python version was previously ignored for caching. Should avoid GHA warnings and speed up jobs.