### PR TITLE
Vis: Fix cropped errorbars

### DIFF
--- a/petab/visualize/plotter.py
+++ b/petab/visualize/plotter.py
@@ -308,7 +308,6 @@ class MPLPlotter(Plotter):
         if not subplot.plotTypeSimulation == BAR_PLOT:
             ax.legend()
         ax.set_title(subplot.plotName)
-        ax.relim()
         if subplot.xlim:
             ax.set_xlim(subplot.xlim)
         if subplot.ylim:


### PR DESCRIPTION
Remove [matplotlib.axes.Axes.relim](https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.relim.html) which ignores error bars ("At present, Collection instances are not supported.")

Fixes #74