### PR TITLE
Fix pandas deprecation warning

### DIFF
--- a/petab/core.py
+++ b/petab/core.py
@@ -209,7 +209,7 @@ def concat_tables(
         if isinstance(tmp_df, (str, Path)):
             tmp_df = file_parser(tmp_df)
 
-        df = df.append(tmp_df, sort=False,
+        df = pd.concat([df, tmp_df], sort=False,
                        ignore_index=isinstance(tmp_df.index, pd.RangeIndex))
 
     return df


### PR DESCRIPTION
FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.