### PR TITLE
Less ambiguous naming in generic output

### DIFF
--- a/petab/problem.py
+++ b/petab/problem.py
@@ -334,7 +334,7 @@ class Problem:
         if self.sbml_document is not None:
             filenames['sbml_file'] = 'model.xml'
 
-        filenames['yaml_file'] = 'problem.yaml'
+        filenames['yaml_file'] = 'petab_problem.yaml'
 
         self.to_files(**filenames, prefix_path=prefix_path)
 


### PR DESCRIPTION
Not really intended use case, but e.g. a PEtab Select problem may exist in the same directory.