### PR TITLE
CI: Run tests only with min+max supported Python version

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.10"]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
Closes #113