### PR TITLE
Fix handling of NaN values for parameters in condition table

### DIFF
--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -410,7 +410,8 @@ def _apply_condition_parameters(par_mapping: ParMappingDict,
         par_mapping[overridee_id] = core.to_float_if_float(
             condition_df.loc[condition_id, overridee_id])
 
-        if np.isnan(par_mapping[overridee_id]):
+        if isinstance(par_mapping[overridee_id], numbers.Number) \
+                and np.isnan(par_mapping[overridee_id]):
             # NaN in the condition table for an entity without time derivative
             #  indicates that the model value should be used
             parameter = sbml_model.getParameter(overridee_id)

--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -409,6 +409,19 @@ def _apply_condition_parameters(par_mapping: ParMappingDict,
 
         par_mapping[overridee_id] = core.to_float_if_float(
             condition_df.loc[condition_id, overridee_id])
+
+        if np.isnan(par_mapping[overridee_id]):
+            # NaN in the condition table for an entity without time derivative
+            #  indicates that the model value should be used
+            parameter = sbml_model.getParameter(overridee_id)
+            if parameter:
+                par_mapping[overridee_id] = parameter.getValue()
+            else:
+                raise NotImplementedError(
+                    "Not sure how to handle NaN in condition table for "
+                    f"{overridee_id}."
+                )
+
         scale_mapping[overridee_id] = LIN
 
 

--- a/tests/test_parameter_mapping.py
+++ b/tests/test_parameter_mapping.py
@@ -4,6 +4,7 @@ import pandas as pd
 import petab
 from petab.parameter_mapping import _apply_parameter_table
 from petab.C import *
+from math import nan
 
 # import fixtures
 pytest_plugins = [
@@ -268,10 +269,18 @@ class TestGetSimulationToOptimizationParameterMapping(object):
     @staticmethod
     def test_partial_override(condition_df_2_conditions):
         # Condition-specific parameters, keeping original parameters
-        condition_df = condition_df_2_conditions
+        condition_df = pd.DataFrame(data={
+            'conditionId': ['condition1', 'condition2'],
+            'conditionName': ['', 'Condition 2'],
+            'fixedParameter1': [1.0, 2.0],
+            'fixedParameter2': [nan, 2.5],
+        })
+        condition_df.set_index('conditionId', inplace=True)
 
         import simplesbml
         ss_model = simplesbml.SbmlModel()
+        ss_model.addParameter('fixedParameter1', 0.5)
+        ss_model.addParameter('fixedParameter2', 1.0)
         ss_model.addParameter('dynamicParameter1', 0.0)
         ss_model.addParameter('observableParameter1_obs1', 0.0)
         ss_model.addParameter('observableParameter2_obs1', 0.0)
@@ -300,6 +309,7 @@ class TestGetSimulationToOptimizationParameterMapping(object):
 
         expected = [({},
                      {'fixedParameter1': 1.0,
+                      'fixedParameter2': 1.0,
                       'dynamicParameter1': 'dynamicParameter1',
                       'observableParameter1_obs1': 'obs1par1override',
                       'observableParameter2_obs1': 'obs1par2cond1override',
@@ -307,12 +317,14 @@ class TestGetSimulationToOptimizationParameterMapping(object):
                       },
                      {},
                      {'fixedParameter1': LIN,
+                      'fixedParameter2': LIN,
                       'dynamicParameter1': LIN,
                       'observableParameter1_obs1': LIN,
                       'observableParameter2_obs1': LIN,
                       'observableParameter1_obs2': LIN}),
                     ({},
                      {'fixedParameter1': 2.0,
+                      'fixedParameter2': 2.5,
                       'dynamicParameter1': 'dynamicParameter1',
                       'observableParameter1_obs1': 'obs1par1override',
                       'observableParameter2_obs1': 'obs1par2cond2override',
@@ -320,6 +332,7 @@ class TestGetSimulationToOptimizationParameterMapping(object):
                       },
                      {},
                      {'fixedParameter1': LIN,
+                      'fixedParameter2': LIN,
                       'dynamicParameter1': LIN,
                       'observableParameter1_obs1': LIN,
                       'observableParameter2_obs1': LIN,


### PR DESCRIPTION
In such cases, the parameter value from the model should be used.
So far, NaN was kept.