### PR TITLE
Fix use of multiple parameter files

### DIFF
--- a/petab/parameters.py
+++ b/petab/parameters.py
@@ -84,10 +84,8 @@ def _check_for_contradicting_parameter_definitions(parameter_df: pd.DataFrame):
                                     parameter_df.index.duplicated()])
     if parameter_duplicates:
         raise ValueError(
-            f'The values of {PARAMETER_ID} must be unique or'
-            ' identical between all parameter subset files. The'
-            ' following duplicates were found:\n'
-            f'{parameter_duplicates}'
+            f'The values of `{PARAMETER_ID}` must be unique. The '
+            f'following duplicates were found:\n{parameter_duplicates}'
         )
 
 

--- a/petab/parameters.py
+++ b/petab/parameters.py
@@ -55,18 +55,8 @@ def get_parameter_df(
             return None
 
         parameter_df = pd.concat(dfs)
-        # Remove identical parameter definitions
-        parameter_df.drop_duplicates(inplace=True, ignore_index=False)
         # Check for contradicting parameter definitions
-        parameter_duplicates = set(parameter_df.index.values[
-                                       parameter_df.index.duplicated()])
-        if parameter_duplicates:
-            raise ValueError(
-                f'The values of {PARAMETER_ID} must be unique or'
-                ' identical between all parameter subset files. The'
-                ' following duplicates were found:\n'
-                f'{parameter_duplicates}'
-            )
+        _check_for_contradicting_parameter_definitions(parameter_df)
 
         return parameter_df
 
@@ -81,8 +71,24 @@ def get_parameter_df(
     except KeyError as e:
         raise KeyError(
             f"Parameter table missing mandatory field {PARAMETER_ID}.") from e
+    _check_for_contradicting_parameter_definitions(parameter_df)
 
     return parameter_df
+
+
+def _check_for_contradicting_parameter_definitions(parameter_df: pd.DataFrame):
+    """
+    Raises a ValueError for non-unique parameter IDs
+    """
+    parameter_duplicates = set(parameter_df.index.values[
+                                    parameter_df.index.duplicated()])
+    if parameter_duplicates:
+        raise ValueError(
+            f'The values of {PARAMETER_ID} must be unique or'
+            ' identical between all parameter subset files. The'
+            ' following duplicates were found:\n'
+            f'{parameter_duplicates}'
+        )
 
 
 def write_parameter_df(df: pd.DataFrame, filename: Union[str, Path]) -> None:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -102,14 +102,15 @@ def test_get_parameter_df():
         # with identical parameter definitions
         with pytest.raises(ValueError):
             petab.get_parameter_df(
-                [parameter_files["subset1"], parameter_files["subset2_redundance"]]
+                [parameter_files["subset1"],
+                 parameter_files["subset2_redundance"]]
             )
         # with non-identical parameter definitions
         with pytest.raises(ValueError):
             petab.get_parameter_df(
-                [parameter_files["subset1"], 
-                parameter_files["subset2_contradiction"],
-                ]
+                [parameter_files["subset1"],
+                 parameter_files["subset2_contradiction"],
+                 ]
             )
 
     # Ensure that parameters that differ only by parameterId
@@ -140,11 +141,11 @@ def test_get_parameter_df():
         assert (df_template == df_test).all().all()
         # several parameter files
         assert petab.get_parameter_df(parameter_files["complete"]).equals(
-            petab.get_parameter_df([parameter_files["subset1"], 
+            petab.get_parameter_df([parameter_files["subset1"],
                                     parameter_files["subset2"]])
         )
 
-        
+
 def test_write_parameter_df():
     """Test parameters.write_parameter_df."""
     parameter_df = pd.DataFrame(data={

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -101,43 +101,48 @@ def test_get_parameter_df():
         # Ensure an error is raised if there exist parameterId duplicates
         # with identical parameter definitions
         with pytest.raises(ValueError):
-            petab.get_parameter_df([parameter_files['subset1'],
-                                    parameter_files['subset2_redundance']])
+            petab.get_parameter_df(
+                [parameter_files["subset1"], parameter_files["subset2_redundance"]]
+            )
         # with non-identical parameter definitions
         with pytest.raises(ValueError):
-            petab.get_parameter_df([parameter_files['subset1'],
-                                    parameter_files['subset2_contradiction']])
-        
-    # Ensure that parameters that differ only by parameterId 
+            petab.get_parameter_df(
+                [parameter_files["subset1"], 
+                parameter_files["subset2_contradiction"],
+                ]
+            )
+
+    # Ensure that parameters that differ only by parameterId
     # are recognized as distinct
     with tempfile.TemporaryDirectory() as directory:
         parameter_dfs, parameter_files = ({}, {})
-        parameter_dfs['complete'] = pd.DataFrame(data={
-            PARAMETER_ID: ['id1', 'id2', 'id3', 'id4'],
-            NOMINAL_VALUE: [1, 1, 1, 1]
-        })
-        parameter_dfs['m1'] = pd.DataFrame(data={
-            PARAMETER_ID: ['id1', 'id2'],
-            NOMINAL_VALUE: [1, 1]
-        })
-        parameter_dfs['m2'] = pd.DataFrame(data={
-            PARAMETER_ID: ['id3', 'id4'],
-            NOMINAL_VALUE: [1, 1]
-        })
+        parameter_dfs["complete"] = pd.DataFrame(
+            data={
+                PARAMETER_ID: ["id1", "id2", "id3", "id4"],
+                NOMINAL_VALUE: [1, 1, 1, 1],
+            }
+        )
+        parameter_dfs["subset1"] = pd.DataFrame(
+            data={PARAMETER_ID: ["id1", "id2"], NOMINAL_VALUE: [1, 1]}
+        )
+        parameter_dfs["subset2"] = pd.DataFrame(
+            data={PARAMETER_ID: ["id3", "id4"], NOMINAL_VALUE: [1, 1]}
+        )
         for name, df in parameter_dfs.items():
             with tempfile.NamedTemporaryFile(
-                    mode='w', delete=False, dir=directory) as fh:
+                mode="w", delete=False, dir=directory
+            ) as fh:
                 parameter_files[name] = fh.name
-                parameter_dfs[name].to_csv(fh, sep='\t', index=False)
+                parameter_dfs[name].to_csv(fh, sep="\t", index=False)
         # from one parameter file
-        df = petab.get_parameter_df(parameter_files['complete'])
-        assert (
-            df == parameter_dfs['complete'].set_index(PARAMETER_ID)
-        ).all().all()
+        df_template = parameter_dfs["complete"].set_index(PARAMETER_ID)
+        df_test = petab.get_parameter_df(parameter_files["complete"])
+        assert (df_template == df_test).all().all()
         # several parameter files
-        assert(petab.get_parameter_df(parameter_files['complete']).equals(
-            petab.get_parameter_df([parameter_files['m1'],
-                                    parameter_files['m2']])))
+        assert petab.get_parameter_df(parameter_files["complete"]).equals(
+            petab.get_parameter_df([parameter_files["subset1"], 
+                                    parameter_files["subset2"]])
+        )
 
         
 def test_write_parameter_df():

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -81,11 +81,11 @@ def test_get_parameter_df():
             PARAMETER_ID: ['id3'],
             PARAMETER_NAME: ['name3']
         })
-        parameter_dfs['subset2_overlap'] = pd.DataFrame(data={
+        parameter_dfs['subset2_redundance'] = pd.DataFrame(data={
             PARAMETER_ID: ['id2', 'id3'],
             PARAMETER_NAME: ['name2', 'name3']
         })
-        parameter_dfs['subset2_error'] = pd.DataFrame(data={
+        parameter_dfs['subset2_contradiction'] = pd.DataFrame(data={
             PARAMETER_ID: ['id2', 'id3'],
             PARAMETER_NAME: ['different_name2', 'name3']
         })
@@ -98,16 +98,16 @@ def test_get_parameter_df():
         assert(petab.get_parameter_df(parameter_files['complete']).equals(
             petab.get_parameter_df([parameter_files['subset1'],
                                     parameter_files['subset2_strict']])))
-        # Check that identical parameter definitions are correctly combined
-        assert(petab.get_parameter_df(parameter_files['complete']).equals(
-            petab.get_parameter_df([parameter_files['subset1'],
-                                    parameter_files['subset2_overlap']])))
         # Ensure an error is raised if there exist parameterId duplicates
+        # with identical parameter definitions
+        with pytest.raises(ValueError):
+            petab.get_parameter_df([parameter_files['subset1'],
+                                    parameter_files['subset2_redundance']])
         # with non-identical parameter definitions
         with pytest.raises(ValueError):
             petab.get_parameter_df([parameter_files['subset1'],
-                                    parameter_files['subset2_error']])
-
+                                    parameter_files['subset2_contradiction']])
+        
 
 def test_write_parameter_df():
     """Test parameters.write_parameter_df."""


### PR DESCRIPTION
When reading in parameter tables using `parameters.get_parameter_df`:
- check all parameter tables (not just those resulting from several parameter files) for contradicting parameter definitions
- remove the removal of duplicate parameters, will instead raise `ValueError`
- ensure that parameters that only differ by their `parameterId` are recognized as distinct and not dropped (fix #154 )
- adjust/extend `test_parameters.py` accordingly