### PR TITLE
GHA: Replace deprecated `set-output`

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -27,7 +27,9 @@ jobs:
       id: pip_cache_dir
       run: |
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
 
+    - run: echo ${{ steps.pip_cache_dir.outputs.dir }}
     - name: Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Get pip cache directory
       id: pip_cache_dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache
       uses: actions/cache@v3

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -26,13 +26,9 @@ jobs:
     - name: Get pip cache directory
       id: pip_cache_dir
       run: |
-        echo "dir=$(pip cache dir)"
-        echo $GITHUB_OUTPUT
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-        cat $GITHUB_OUTPUT
       shell: bash
 
-    - run: echo ${{ steps.pip_cache_dir.outputs.dir }}
     - name: Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -30,6 +30,7 @@ jobs:
         echo $GITHUB_OUTPUT
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
+      shell: bash
 
     - run: echo ${{ steps.pip_cache_dir.outputs.dir }}
     - name: Cache

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -26,6 +26,8 @@ jobs:
     - name: Get pip cache directory
       id: pip_cache_dir
       run: |
+        echo "dir=$(pip cache dir)"
+        echo $GITHUB_OUTPUT
         echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
 


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/