### PR TITLE
Simulator: rename measurement column to simulation

### DIFF
--- a/petab/simulate.py
+++ b/petab/simulate.py
@@ -137,10 +137,12 @@ class Simulator(abc.ABC):
         simulation_df = self.simulate_without_noise(**kwargs)
         if noise:
             simulation_df = self.add_noise(simulation_df, noise_scaling_factor)
-        if not as_measurement:
-            simulation_df = simulation_df.rename(
-                columns={petab.C.MEASUREMENT: petab.C.SIMULATION},
-            )
+
+        columns = {petab.C.MEASUREMENT: petab.C.SIMULATION}
+        if as_measurement:
+            columns = {petab.C.SIMULATION: petab.C.MEASUREMENT}
+        simulation_df = simulation_df.rename(columns=columns)
+
         return simulation_df
 
     def add_noise(

--- a/petab/simulate.py
+++ b/petab/simulate.py
@@ -115,7 +115,7 @@ class Simulator(abc.ABC):
             self,
             noise: bool = False,
             noise_scaling_factor: float = 1,
-            rename: bool = False,
+            as_measurement: bool = False,
             **kwargs
     ) -> pd.DataFrame:
         """Simulate a PEtab problem, optionally with noise.
@@ -124,9 +124,9 @@ class Simulator(abc.ABC):
             noise: If True, noise is added to simulated data.
             noise_scaling_factor:
                 A multiplier of the scale of the noise distribution.
-            rename:
-                Whether to rename the measurement column from
-                :const:`petab.C.MEASUREMENT` to :const:`petab.C.SIMULATION`.
+            as_measurement:
+                Whether the data column is named :const:`petab.C.MEASUREMENT`
+                (`True`) or :const:`petab.C.SIMULATION` (`False`).
             **kwargs:
                 Additional keyword arguments are passed to
                 :meth:`petab.simulate.Simulator.simulate_without_noise`.
@@ -137,7 +137,7 @@ class Simulator(abc.ABC):
         simulation_df = self.simulate_without_noise(**kwargs)
         if noise:
             simulation_df = self.add_noise(simulation_df, noise_scaling_factor)
-        if rename:
+        if not as_measurement:
             simulation_df = simulation_df.rename(
                 columns={petab.C.MEASUREMENT: petab.C.SIMULATION},
             )

--- a/petab/simulate.py
+++ b/petab/simulate.py
@@ -115,6 +115,7 @@ class Simulator(abc.ABC):
             self,
             noise: bool = False,
             noise_scaling_factor: float = 1,
+            rename: bool = False,
             **kwargs
     ) -> pd.DataFrame:
         """Simulate a PEtab problem, optionally with noise.
@@ -123,6 +124,9 @@ class Simulator(abc.ABC):
             noise: If True, noise is added to simulated data.
             noise_scaling_factor:
                 A multiplier of the scale of the noise distribution.
+            rename:
+                Whether to rename the measurement column from
+                :const:`petab.C.MEASUREMENT` to :const:`petab.C.SIMULATION`.
             **kwargs:
                 Additional keyword arguments are passed to
                 :meth:`petab.simulate.Simulator.simulate_without_noise`.
@@ -133,6 +137,10 @@ class Simulator(abc.ABC):
         simulation_df = self.simulate_without_noise(**kwargs)
         if noise:
             simulation_df = self.add_noise(simulation_df, noise_scaling_factor)
+        if rename:
+            simulation_df = simulation_df.rename(
+                columns={petab.C.MEASUREMENT: petab.C.SIMULATION},
+            )
         return simulation_df
 
     def add_noise(

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -84,21 +84,21 @@ def test_zero_bounded(petab_problem):
         (positive if index in pos_indices else np.nan)
         for index in range(n_measurements)
     ]
-    synthetic_data_df = simulator.simulate().assign(**{
+    synthetic_data_df = simulator.simulate(as_measurement=True).assign(**{
         petab.C.MEASUREMENT: measurements
     })
     # All measurements are non-zero
-    assert (synthetic_data_df['measurement'] != 0).all()
+    assert (synthetic_data_df[MEASUREMENT] != 0).all()
     # No measurements are NaN
-    assert not (np.isnan(synthetic_data_df['measurement'])).any()
+    assert not (np.isnan(synthetic_data_df[MEASUREMENT])).any()
 
     synthetic_data_df_with_noise = simulator.add_noise(
         synthetic_data_df,
     )
     # Both negative and positive values are returned by default.
     assert all([
-        (synthetic_data_df_with_noise['measurement'] <= 0).any(),
-        (synthetic_data_df_with_noise['measurement'] >= 0).any(),
+        (synthetic_data_df_with_noise[MEASUREMENT] <= 0).any(),
+        (synthetic_data_df_with_noise[MEASUREMENT] >= 0).any(),
     ])
 
     synthetic_data_df_with_noise = simulator.add_noise(
@@ -108,12 +108,12 @@ def test_zero_bounded(petab_problem):
     # Values with noise that are different in sign to values without noise are
     # zeroed.
     assert all([
-        (synthetic_data_df_with_noise['measurement'][neg_indices] <= 0).all(),
-        (synthetic_data_df_with_noise['measurement'][pos_indices] >= 0).all(),
-        (synthetic_data_df_with_noise['measurement'][neg_indices] == 0).any(),
-        (synthetic_data_df_with_noise['measurement'][pos_indices] == 0).any(),
-        (synthetic_data_df_with_noise['measurement'][neg_indices] < 0).any(),
-        (synthetic_data_df_with_noise['measurement'][pos_indices] > 0).any(),
+        (synthetic_data_df_with_noise[MEASUREMENT][neg_indices] <= 0).all(),
+        (synthetic_data_df_with_noise[MEASUREMENT][pos_indices] >= 0).all(),
+        (synthetic_data_df_with_noise[MEASUREMENT][neg_indices] == 0).any(),
+        (synthetic_data_df_with_noise[MEASUREMENT][pos_indices] == 0).any(),
+        (synthetic_data_df_with_noise[MEASUREMENT][neg_indices] < 0).any(),
+        (synthetic_data_df_with_noise[MEASUREMENT][pos_indices] > 0).any(),
     ])
 
 
@@ -148,7 +148,7 @@ def _test_add_noise(petab_problem) -> None:
     simulator = TestSimulator(petab_problem)
     # Set the random seed to ensure predictable tests.
     simulator.rng = np.random.default_rng(seed=0)
-    synthetic_data_df = simulator.simulate()
+    synthetic_data_df = simulator.simulate(as_measurement=True)
 
     # Generate samples of noisy data
     samples = []


### PR DESCRIPTION
What's your opinion on whether to default to `measurement` or `simulation`? Either is fine for me. Currently I am in favor of keeping `measurement`, because:
- I have mostly used this for synthetic data generation
- It won't break user code

However, I see that `simulation` might be what users expect from a simulator.

see also: AMICI-dev/AMICI#2050 and AMICI-dev/AMICI#2051