### PR TITLE
Fix sympy symbol name clashes

### DIFF
--- a/petab/calculate.py
+++ b/petab/calculate.py
@@ -6,9 +6,10 @@ from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd
-import petab
 import sympy
+from sympy.abc import _clash
 
+import petab
 from .C import *
 
 __all__ = ['calculate_residuals', 'calculate_residuals_for_table',
@@ -138,7 +139,7 @@ def get_symbolic_noise_formulas(observable_df) -> Dict[str, sympy.Expr]:
         if NOISE_FORMULA not in observable_df.columns:
             noise_formula = None
         else:
-            noise_formula = sympy.sympify(row.noiseFormula)
+            noise_formula = sympy.sympify(row.noiseFormula, locals=_clash)
         noise_formulas[observable_id] = noise_formula
     return noise_formulas
 

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -4,17 +4,18 @@ import copy
 import logging
 import numbers
 import re
-from typing import Optional, Iterable, Any
 from collections import Counter
+from typing import Any, Iterable, Optional
 
 import numpy as np
 import pandas as pd
 import sympy as sp
+from sympy.abc import _clash
 
 import petab
-from . import (core, parameters, measurements)
-from .models import Model
+from . import (core, measurements, parameters)
 from .C import *  # noqa: F403
+from .models import Model
 
 logger = logging.getLogger(__name__)
 __all__ = ['assert_all_parameters_present_in_parameter_df',
@@ -287,7 +288,7 @@ def check_observable_df(observable_df: pd.DataFrame) -> None:
     for row in observable_df.itertuples():
         obs = getattr(row, OBSERVABLE_FORMULA)
         try:
-            sp.sympify(obs)
+            sp.sympify(obs, locals=_clash)
         except sp.SympifyError as e:
             raise AssertionError(
                 f"Cannot parse expression '{obs}' "
@@ -295,7 +296,7 @@ def check_observable_df(observable_df: pd.DataFrame) -> None:
 
         noise = getattr(row, NOISE_FORMULA)
         try:
-            sympified_noise = sp.sympify(noise)
+            sympified_noise = sp.sympify(noise, locals=_clash)
             if sympified_noise is None \
                     or (sympified_noise.is_Number
                         and not sympified_noise.is_finite):

--- a/petab/observables.py
+++ b/petab/observables.py
@@ -3,10 +3,11 @@
 import re
 from collections import OrderedDict
 from pathlib import Path
-from typing import List, Union, Literal
+from typing import List, Literal, Union
 
 import pandas as pd
 import sympy as sp
+from sympy.abc import _clash
 
 from . import core, lint
 from .C import *  # noqa: F403
@@ -97,7 +98,7 @@ def get_output_parameters(
     output_parameters = OrderedDict()
 
     for formula in formulas:
-        free_syms = sorted(sp.sympify(formula).free_symbols,
+        free_syms = sorted(sp.sympify(formula, locals=_clash).free_symbols,
                            key=lambda symbol: symbol.name)
         for free_sym in free_syms:
             sym = str(free_sym)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -483,29 +483,6 @@ def test_check_parameter_df():
         lint.check_parameter_df(df=parameter_df)
 
 
-def test_check_observable_df():
-    """Check that we correctly detect errors in observable table"""
-
-    observable_df = pd.DataFrame(data={
-        OBSERVABLE_ID: ['obs1', 'obs2'],
-        OBSERVABLE_FORMULA: ['x1', 'x2'],
-        NOISE_FORMULA: ['sigma1', 'sigma2']
-    }).set_index(OBSERVABLE_ID)
-
-    lint.check_observable_df(observable_df)
-
-    # Check that duplicated observables ids are detected
-    bad_observable_df = observable_df.copy()
-    bad_observable_df.index = ['obs1', 'obs1']
-    with pytest.raises(AssertionError):
-        lint.check_observable_df(bad_observable_df)
-
-    # Check that missing noiseFormula is detected
-    bad_observable_df = observable_df.copy()
-    bad_observable_df.loc['obs1', NOISE_FORMULA] = nan
-    with pytest.raises(AssertionError):
-        lint.check_observable_df(bad_observable_df)
-
 
 def test_condition_ids_are_unique():
     condition_df = pd.DataFrame(data={

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -483,6 +483,29 @@ def test_check_parameter_df():
         lint.check_parameter_df(df=parameter_df)
 
 
+def test_check_observable_df():
+    """Check that we correctly detect errors in observable table"""
+
+    observable_df = pd.DataFrame(data={
+        OBSERVABLE_ID: ['obs1', 'obs2'],
+        OBSERVABLE_FORMULA: ['x1', 'x2'],
+        NOISE_FORMULA: ['sigma1', 'sigma2']
+    }).set_index(OBSERVABLE_ID)
+
+    lint.check_observable_df(observable_df)
+
+    # Check that duplicated observables ids are detected
+    bad_observable_df = observable_df.copy()
+    bad_observable_df.index = ['obs1', 'obs1']
+    with pytest.raises(AssertionError):
+        lint.check_observable_df(bad_observable_df)
+
+    # Check that missing noiseFormula is detected
+    bad_observable_df = observable_df.copy()
+    bad_observable_df.loc['obs1', NOISE_FORMULA] = nan
+    with pytest.raises(AssertionError):
+        lint.check_observable_df(bad_observable_df)
+
 
 def test_condition_ids_are_unique():
     condition_df = pd.DataFrame(data={

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -83,6 +83,20 @@ def test_get_output_parameters():
 
     assert output_parameters == ['offset', 'scaling']
 
+    # test sympy-special symbols (e.g. N, beta, ...)
+    # see https://github.com/ICB-DCM/pyPESTO/issues/1048
+    observable_df = pd.DataFrame(data={
+        OBSERVABLE_ID: ['observable_1'],
+        OBSERVABLE_NAME: ['observable name 1'],
+        OBSERVABLE_FORMULA: ['observable_1 * N + beta'],
+        NOISE_FORMULA: [1],
+    }).set_index(OBSERVABLE_ID)
+
+    output_parameters = petab.get_output_parameters(
+        observable_df, SbmlModel(sbml_model=ss_model.model))
+
+    assert output_parameters == ['N', 'beta']
+
 
 def test_get_formula_placeholders():
     """Test get_formula_placeholders"""


### PR DESCRIPTION
Make sure symbols like `N`, `beta`, ... are used as scalar symbols, and not as sympy functions with the same name.

See also https://github.com/ICB-DCM/pyPESTO/issues/1048