### PR TITLE
Make `SbmlModel.from_file(..., model_id)` optional

### DIFF
--- a/petab/models/sbml_model.py
+++ b/petab/models/sbml_model.py
@@ -59,7 +59,7 @@ class SbmlModel(Model):
         self.__dict__.update(state)
 
     @staticmethod
-    def from_file(filepath_or_buffer, model_id: str):
+    def from_file(filepath_or_buffer, model_id: str = None):
         sbml_reader, sbml_document, sbml_model = get_sbml_model(
             filepath_or_buffer)
         return SbmlModel(


### PR DESCRIPTION
The constructor has a default of `None`, which it handles by taking the ID attribute from the SBML model.