### PR TITLE
Make validate_visualization_df work without matplotlib installation

### DIFF
--- a/petab/visualize/__init__.py
+++ b/petab/visualize/__init__.py
@@ -34,6 +34,4 @@ if mpl_spec is not None:
         "plot_goodness_of_fit",
         "plot_residuals_vs_simulation",
         "MPLPlotter",
-        "DataProvider",
-        "Figure"
     ])

--- a/petab/visualize/__init__.py
+++ b/petab/visualize/__init__.py
@@ -6,24 +6,34 @@ PEtab comes with visualization functionality. Those need to be imported via
 ``import petab.visualize``.
 
 """
+import importlib.util
 
-from .plot_data_and_simulation import (
-    plot_without_vis_spec,
-    plot_with_vis_spec,
-    plot_problem,
-)
+mpl_spec = importlib.util.find_spec("matplotlib")
 
-from .plot_residuals import plot_goodness_of_fit, plot_residuals_vs_simulation
-from .plotter import MPLPlotter
 from .plotting import DataProvider, Figure
 
 __all__ = [
-    "plot_without_vis_spec",
-    "plot_with_vis_spec",
-    "plot_problem",
-    "plot_goodness_of_fit",
-    "plot_residuals_vs_simulation",
-    "MPLPlotter",
     "DataProvider",
     "Figure"
 ]
+
+if mpl_spec is not None:
+    from .plot_data_and_simulation import (
+        plot_without_vis_spec,
+        plot_with_vis_spec,
+        plot_problem,
+    )
+
+    from .plot_residuals import plot_goodness_of_fit, plot_residuals_vs_simulation
+    from .plotter import MPLPlotter
+
+    __all__.extend([
+        "plot_without_vis_spec",
+        "plot_with_vis_spec",
+        "plot_problem",
+        "plot_goodness_of_fit",
+        "plot_residuals_vs_simulation",
+        "MPLPlotter",
+        "DataProvider",
+        "Figure"
+    ])


### PR DESCRIPTION
Only import plotting functions in `petab.visualize` if matplotlib is installed.

Closes #212