### PR TITLE
Customizable figure size

### DIFF
--- a/petab/visualize/plotting.py
+++ b/petab/visualize/plotting.py
@@ -20,6 +20,8 @@ __all__ = ['DataSeries', 'DataPlot', 'Subplot', 'Figure', 'DataProvider',
 IdsList = List[str]
 NumList = List[int]
 
+# The default figure size
+DEFAULT_FIGSIZE = (20, 15)
 
 # also for type hints
 # TODO: split into dataplot and subplot level dicts?
@@ -262,7 +264,7 @@ class Figure:
     Contains information regarding how data should be visualized.
     """
     def __init__(self, subplots: Optional[List[Subplot]] = None,
-                 size: Tuple = (20, 15),
+                 size: Tuple = DEFAULT_FIGSIZE,
                  title: Optional[Tuple] = None):
         """
         Constructor.


### PR DESCRIPTION
Currently, there is no easy way to change figure sizes when using high-level visualization functions such as `plot_problem`.
Generally, I'd prefer controlling plotting through matplotlib's `rcParams`, but this change provides at least some backwards-compatible means of changing figure sizes at a higher level by, e.g. `petab.visualize.plotting.DEFAULT_FIGSIZE = (8, 4)`.