### PR TITLE
Handle missing nominalValue in Problem.get_x_nominal

### DIFF
--- a/petab/problem.py
+++ b/petab/problem.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from math import nan
 from pathlib import Path, PurePosixPath
 from typing import Dict, Iterable, List, Optional, Union, TYPE_CHECKING
 from urllib.parse import unquote, urlparse, urlunparse
@@ -660,7 +661,11 @@ class Problem:
         -------
         The parameter nominal values.
         """
-        v = list(self.parameter_df[NOMINAL_VALUE])
+        if NOMINAL_VALUE in self.parameter_df:
+            v = list(self.parameter_df[NOMINAL_VALUE])
+        else:
+            v = [nan] * len(self.parameter_df)
+
         if scaled:
             v = list(parameters.map_scale(
                 v, self.parameter_df[PARAMETER_SCALE]))

--- a/tests/test_petab.py
+++ b/tests/test_petab.py
@@ -557,6 +557,11 @@ def test_parameter_properties(petab_problem):  # pylint: disable=W0621
     assert petab_problem.x_nominal_free_scaled == [7, np.log(8)]
     assert petab_problem.x_nominal_fixed_scaled == [np.log10(9)]
 
+    # Check that a missing nominalValues column is handled correctly
+    del petab_problem.parameter_df[NOMINAL_VALUE]
+    assert len(petab_problem.x_nominal) == 3
+    assert np.isnan(petab_problem.x_nominal).all()
+
 
 def test_to_float_if_float():
     to_float_if_float = petab.core.to_float_if_float


### PR DESCRIPTION
It doesn't seem to be quite clear if the `nominalValue` column needs to be present if all parameters are estimated.
However, since it's allowed to leave `nominalValue` empty, which is treated as NaN, it seems to make sense to treat a missing  `nominalValue` column as all-NaN.

See also https://github.com/ICB-DCM/pyPESTO/issues/1104