### PR TITLE
Startpoint sampling for a subset of parameters

### DIFF
--- a/petab/parameters.py
+++ b/petab/parameters.py
@@ -424,19 +424,25 @@ def get_valid_parameters_for_parameter_table(
 def get_priors_from_df(
     parameter_df: pd.DataFrame,
     mode: Literal["initialization", "objective"],
+    parameter_ids: Sequence[str] = None,
 ) -> List[Tuple]:
     """Create list with information about the parameter priors
 
     Arguments:
         parameter_df: PEtab parameter table
         mode: ``'initialization'`` or ``'objective'``
+        parameter_ids: A sequence of parameter IDs for which to sample starting points.
+            For subsetting or reordering the parameters.
+            Defaults to all estimated parameters.
 
     Returns:
         List with prior information.
     """
-
     # get types and parameters of priors from dataframe
     par_to_estimate = parameter_df.loc[parameter_df[ESTIMATE] == 1]
+
+    if parameter_ids:
+        par_to_estimate = par_to_estimate.loc[parameter_ids, :]
 
     prior_list = []
     for _, row in par_to_estimate.iterrows():

--- a/petab/parameters.py
+++ b/petab/parameters.py
@@ -442,7 +442,13 @@ def get_priors_from_df(
     par_to_estimate = parameter_df.loc[parameter_df[ESTIMATE] == 1]
 
     if parameter_ids:
-        par_to_estimate = par_to_estimate.loc[parameter_ids, :]
+        try:
+            par_to_estimate = par_to_estimate.loc[parameter_ids, :]
+        except KeyError as e:
+            missing_ids = set(parameter_ids) - set(par_to_estimate.index)
+            raise KeyError(
+                f"Parameter table does not contain estimated parameter(s) {missing_ids}."
+            ) from e
 
     prior_list = []
     for _, row in par_to_estimate.iterrows():

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -930,13 +930,13 @@ class Problem:
             **kwargs,
         )
 
-    def sample_parameter_startpoints(self, n_starts: int = 100):
+    def sample_parameter_startpoints(self, n_starts: int = 100, **kwargs):
         """Create 2D array with starting points for optimization
 
         See :py:func:`petab.sample_parameter_startpoints`.
         """
         return sampling.sample_parameter_startpoints(
-            self.parameter_df, n_starts=n_starts
+            self.parameter_df, n_starts=n_starts, **kwargs
         )
 
     def sample_parameter_startpoints_dict(

--- a/petab/sampling.py
+++ b/petab/sampling.py
@@ -1,6 +1,6 @@
 """Functions related to parameter sampling"""
 
-from typing import Tuple
+from typing import Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -110,6 +110,7 @@ def sample_parameter_startpoints(
     parameter_df: pd.DataFrame,
     n_starts: int = 100,
     seed: int = None,
+    parameter_ids: Sequence[str] = None,
 ) -> np.array:
     """Create :class:`numpy.array` with starting points for an optimization
 
@@ -117,17 +118,20 @@ def sample_parameter_startpoints(
         parameter_df: PEtab parameter DataFrame
         n_starts: Number of points to be sampled
         seed: Random number generator seed (see :func:`numpy.random.seed`)
+        parameter_ids: A sequence of parameter IDs for which to sample starting points.
+            For subsetting or reordering the parameters.
+            Defaults to all estimated parameters.
 
     Returns:
         Array of sampled starting points with dimensions
-        n_startpoints x n_optimization_parameters
+        `n_startpoints` x `n_optimization_parameters`
     """
     if seed is not None:
         np.random.seed(seed)
 
     # get types and parameters of priors from dataframe
     prior_list = parameters.get_priors_from_df(
-        parameter_df, mode=INITIALIZATION
+        parameter_df, mode=INITIALIZATION, parameter_ids=parameter_ids
     )
 
     startpoints = [sample_from_prior(prior, n_starts) for prior in prior_list]

--- a/tests/test_petab.py
+++ b/tests/test_petab.py
@@ -234,6 +234,11 @@ def test_get_priors_from_df():
     assert len(prior_list_subset) == 2
     assert prior_list_subset == [prior_list[1], prior_list[0]]
 
+    with pytest.raises(KeyError, match="Parameter table does not contain"):
+        petab.get_priors_from_df(
+            parameter_df, mode=INITIALIZATION, parameter_ids=["non_existent"]
+        )
+
 
 def test_startpoint_sampling(fujita_model_scaling):
     n_starts = 10

--- a/tests/test_petab.py
+++ b/tests/test_petab.py
@@ -179,6 +179,7 @@ def test_get_priors_from_df():
     """Check petab.get_priors_from_df."""
     parameter_df = pd.DataFrame(
         {
+            PARAMETER_ID: ["p1", "p2", "p3", "p4", "p5"],
             PARAMETER_SCALE: [LOG10, LOG10, LOG10, LOG10, LOG10],
             LOWER_BOUND: [1e-8, 1e-9, 1e-10, 1e-11, 1e-5],
             UPPER_BOUND: [1e8, 1e9, 1e10, 1e11, 1e5],
@@ -193,6 +194,7 @@ def test_get_priors_from_df():
             ],
         }
     )
+    parameter_df = petab.get_parameter_df(parameter_df)
 
     prior_list = petab.get_priors_from_df(parameter_df, mode=INITIALIZATION)
 
@@ -224,6 +226,13 @@ def test_get_priors_from_df():
     assert prior_pars[0] == (-8, 8)
     assert prior_pars[1] == (-5, 5)
     assert prior_pars[2] == (1e-5, 1e5)
+
+    # check subsetting / reordering works
+    prior_list_subset = petab.get_priors_from_df(
+        parameter_df, mode=INITIALIZATION, parameter_ids=["p2", "p1"]
+    )
+    assert len(prior_list_subset) == 2
+    assert prior_list_subset == [prior_list[1], prior_list[0]]
 
 
 def test_startpoint_sampling(fujita_model_scaling):


### PR DESCRIPTION
Allow passing a list of parameter IDs to startpoint sampling for subsetting/reordering parameters.