### PR TITLE
Require pyarrow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
     install_requires=[
         "numpy>=1.15.1",
         "pandas>=1.2.0",
+        "pyarrow",
         "python-libsbml>=5.17.0",
         "sympy",
         "colorama",

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ setup(
     install_requires=[
         "numpy>=1.15.1",
         "pandas>=1.2.0",
+        # remove when pandas >= 3, see also
+        # https://github.com/pandas-dev/pandas/issues/54466
         "pyarrow",
         "python-libsbml>=5.17.0",
         "sympy",


### PR DESCRIPTION
Avoids
```
.tox\unit\lib\site-packages\pandas\__init__.py:249: in <module>
    warnings.warn(
E   DeprecationWarning:
E   Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
E   (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
E   but was not found to be installed on your system.
E   If this would cause problems for you,
E   please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```