### PR TITLE
Fix pytest.PytestRemovedIn9Warning / Marks applied to fixtures

### DIFF
--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -107,7 +107,6 @@ def visu_file_Fujita_minimal():
     )
 
 
-@pytest.mark.filterwarnings("ignore:Visualization table is empty")
 @pytest.fixture
 def visu_file_Fujita_empty():
     return (


### PR DESCRIPTION
Fixes

```
_________________ ERROR collecting tests/test_visualization.py _________________
tests/test_visualization.py:112: in <module>
    def visu_file_Fujita_empty():
.tox/unit/lib/python3.9/site-packages/_pytest/mark/structures.py:357: in __call__
    store_mark(func, self.mark)
.tox/unit/lib/python3.9/site-packages/_pytest/mark/structures.py:422: in store_mark
    warnings.warn(MARKED_FIXTURE, stacklevel=2)
E   pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
E   See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
```

https://github.com/PEtab-dev/libpetab-python/actions/runs/7691314124/job/20956434711