### PR TITLE
maint: black -> ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-- repo: https://github.com/pycqa/isort
-  rev: 5.12.0
-  hooks:
-    - id: isort
-      name: isort (python)
-      args: ["--profile", "black", "--filter-files", "--line-length", "79"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:
@@ -16,13 +10,19 @@ repos:
     args: [--allow-multiple-documents]
   - id: end-of-file-fixer
   - id: trailing-whitespace
-- repo: https://github.com/psf/black
-  rev: 23.7.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.1.11
   hooks:
-    - id: black-jupyter
-      # It is recommended to specify the latest version of Python
-      # supported by your project here, or alternatively use
-      # pre-commit's default_language_version, see
-      # https://pre-commit.com/#top_level-default_language_version
-      language_version: python3.11
-      args: ["--line-length", "79"]
+    # Run the linter.
+    - id: ruff
+      args:
+        - --fix
+        - --config
+        - pyproject.toml
+
+    # Run the formatter.
+    - id: ruff-format
+      args:
+        - --config
+        - pyproject.toml

--- a/petab/calculate.py
+++ b/petab/calculate.py
@@ -322,7 +322,8 @@ def calculate_llh_for_table(
     parameter_df: pd.DataFrame,
 ) -> float:
     """Calculate log-likelihood for one set of tables. For the arguments, see
-    `calculate_llh`."""
+    `calculate_llh`.
+    """
     llhs = []
 
     # matching columns

--- a/petab/composite_problem.py
+++ b/petab/composite_problem.py
@@ -46,7 +46,6 @@ class CompositeProblem:
         Arguments:
             yaml_config: PEtab configuration as dictionary or YAML file name
         """
-
         if isinstance(yaml_config, str):
             path_prefix = os.path.dirname(yaml_config)
             yaml_config = yaml.load_yaml(yaml_config)

--- a/petab/conditions.py
+++ b/petab/conditions.py
@@ -18,7 +18,7 @@ __all__ = [
 
 
 def get_condition_df(
-    condition_file: Union[str, pd.DataFrame, Path, None]
+    condition_file: Union[str, pd.DataFrame, Path, None],
 ) -> pd.DataFrame:
     """Read the provided condition file into a ``pandas.Dataframe``
 
@@ -75,7 +75,6 @@ def create_condition_df(
         A :py:class:`pandas.DataFrame` with empty given rows and columns and
         all nan values
     """
-
     condition_ids = [] if condition_ids is None else list(condition_ids)
 
     data = {CONDITION_ID: condition_ids}

--- a/petab/core.py
+++ b/petab/core.py
@@ -72,7 +72,7 @@ def write_simulation_df(df: pd.DataFrame, filename: Union[str, Path]) -> None:
 
 
 def get_visualization_df(
-    visualization_file: Union[str, Path, pd.DataFrame, None]
+    visualization_file: Union[str, Path, pd.DataFrame, None],
 ) -> Union[pd.DataFrame, None]:
     """Read PEtab visualization table
 
@@ -357,7 +357,6 @@ def concat_tables(
     Returns:
         The concatenated DataFrames
     """
-
     if isinstance(tables, pd.DataFrame):
         return tables
 
@@ -389,7 +388,6 @@ def to_float_if_float(x: Any) -> Any:
     Returns:
         ``x`` as float if possible, otherwise ``x``
     """
-
     try:
         return float(x)
     except (ValueError, TypeError):
@@ -427,7 +425,6 @@ def create_combine_archive(
         email: E-mail address of archive creator
         organization: Organization of archive creator
     """
-
     path_prefix = os.path.dirname(str(yaml_file))
     yaml_config = yaml.load_yaml(yaml_file)
 

--- a/petab/lint.py
+++ b/petab/lint.py
@@ -105,7 +105,6 @@ def check_condition_df(
     Raises:
         AssertionError: in case of problems
     """
-
     # Check required columns are present
     req_cols = []
     _check_df(df, req_cols, "condition")
@@ -167,7 +166,6 @@ def check_measurement_df(
     Raises:
         AssertionError, ValueError: in case of problems
     """
-
     _check_df(df, MEASUREMENT_DF_REQUIRED_COLS, "measurement")
 
     for column_name in MEASUREMENT_DF_REQUIRED_COLS:
@@ -432,7 +430,6 @@ def assert_measured_observables_defined(
     Raises:
         AssertionError: in case of problems
     """
-
     used_observables = set(measurement_df[OBSERVABLE_ID].values)
     defined_observables = set(observable_df.index.values)
     if undefined_observables := (used_observables - defined_observables):
@@ -453,7 +450,6 @@ def condition_table_is_parameter_free(condition_df: pd.DataFrame) -> bool:
         ``True`` if there are no parameter overrides in the condition table,
         ``False`` otherwise.
     """
-
     return len(petab.get_parametric_overrides(condition_df)) == 0
 
 
@@ -468,7 +464,6 @@ def assert_parameter_id_is_string(parameter_df: pd.DataFrame) -> None:
     Raises:
         AssertionError: in case of problems
     """
-
     for parameter_id in parameter_df:
         if isinstance(parameter_id, str):
             if parameter_id[0].isdigit():
@@ -1088,7 +1083,6 @@ def assert_measurement_conditions_present_in_condition_table(
     Raises:
         AssertionError: in case of problems
     """
-
     used_conditions = set(measurement_df[SIMULATION_CONDITION_ID].values)
     if PREEQUILIBRATION_CONDITION_ID in measurement_df:
         used_conditions |= set(

--- a/petab/mapping.py
+++ b/petab/mapping.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 def get_mapping_df(
-    mapping_file: Union[None, str, Path, pd.DataFrame]
+    mapping_file: Union[None, str, Path, pd.DataFrame],
 ) -> pd.DataFrame:
     """
     Read the provided mapping file into a ``pandas.Dataframe``.

--- a/petab/measurements.py
+++ b/petab/measurements.py
@@ -28,7 +28,7 @@ __all__ = [
 
 
 def get_measurement_df(
-    measurement_file: Union[None, str, Path, pd.DataFrame]
+    measurement_file: Union[None, str, Path, pd.DataFrame],
 ) -> pd.DataFrame:
     """
     Read the provided measurement file into a ``pandas.Dataframe``.
@@ -217,7 +217,6 @@ def create_measurement_df() -> pd.DataFrame:
     Returns:
         Created DataFrame
     """
-
     return pd.DataFrame(
         data={
             OBSERVABLE_ID: [],

--- a/petab/models/model.py
+++ b/petab/models/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import abc
 from pathlib import Path
-from typing import Any, Iterable, Tuple
+from typing import Any, Iterable
 
 
 class Model(abc.ABC):
@@ -55,7 +55,7 @@ class Model(abc.ABC):
     @abc.abstractmethod
     def get_free_parameter_ids_with_values(
         self,
-    ) -> Iterable[Tuple[str, float]]:
+    ) -> Iterable[tuple[str, float]]:
         """Get free model parameters along with their values
 
         Returns:
@@ -106,7 +106,6 @@ class Model(abc.ABC):
 
         :returns: ``True``, if allowed, ``False`` otherwise
         """
-
         ...
 
     @abc.abstractmethod

--- a/petab/observables.py
+++ b/petab/observables.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 def get_observable_df(
-    observable_file: Union[str, pd.DataFrame, Path, None]
+    observable_file: Union[str, pd.DataFrame, Path, None],
 ) -> Union[pd.DataFrame, None]:
     """
     Read the provided observable file into a ``pandas.Dataframe``.
@@ -191,7 +191,6 @@ def get_placeholders(
         List of placeholder parameters from observable table observableFormulas
         and noiseFormulas.
     """
-
     # collect placeholder parameters overwritten by
     # {observable,noise}Parameters
     placeholder_types = []
@@ -224,5 +223,4 @@ def create_observable_df() -> pd.DataFrame:
     Returns:
         Created DataFrame
     """
-
     return pd.DataFrame(data={col: [] for col in OBSERVABLE_DF_COLS})

--- a/petab/parameter_mapping.py
+++ b/petab/parameter_mapping.py
@@ -1,5 +1,6 @@
 """Functions related to mapping parameter from model to parameter estimation
-problem"""
+problem
+"""
 
 import logging
 import numbers
@@ -234,7 +235,6 @@ def _map_condition(packed_args):
     For arguments see
     :py:func:`get_optimization_to_simulation_parameter_mapping`.
     """
-
     (
         condition,
         measurement_df,
@@ -564,7 +564,6 @@ def _apply_parameter_table(
         parameter_df:
             PEtab parameter table
     """
-
     if parameter_df is None:
         return
 
@@ -626,8 +625,8 @@ def _perform_mapping_checks(
     allow_timepoint_specific_numeric_noise_parameters: bool = False,
 ) -> None:
     """Check for PEtab features which we can't account for during parameter
-    mapping."""
-
+    mapping.
+    """
     if lint.measurement_table_has_timepoint_specific_mappings(
         measurement_df,
         allow_scalar_numeric_noise_parameters=allow_timepoint_specific_numeric_noise_parameters,  # noqa: E251,E501

--- a/petab/parameters.py
+++ b/petab/parameters.py
@@ -45,7 +45,7 @@ PARAMETER_SCALE_ARGS = Literal["", "lin", "log", "log10"]
 def get_parameter_df(
     parameter_file: Union[
         str, Path, pd.DataFrame, Iterable[Union[str, Path, pd.DataFrame]], None
-    ]
+    ],
 ) -> Union[pd.DataFrame, None]:
     """
     Read the provided parameter file into a ``pandas.Dataframe``.
@@ -301,19 +301,22 @@ def get_required_parameters_for_parameter_table(
     for formula_type, placeholder_sources in (
         (
             # Observable formulae
-            {'observables': True, 'noise': False},
+            {"observables": True, "noise": False},
             # can only contain observable placeholders
-            {'noise': False, 'observables': True}
+            {"noise": False, "observables": True},
         ),
         (
             # Noise formulae
-            {'observables': False, 'noise': True},
+            {"observables": False, "noise": True},
             # can contain noise and observable placeholders
-            {'noise': True, 'observables': True}
+            {"noise": True, "observables": True},
         ),
     ):
         output_parameters = observables.get_output_parameters(
-            observable_df, model, mapping_df=mapping_df, **formula_type,
+            observable_df,
+            model,
+            mapping_df=mapping_df,
+            **formula_type,
         )
         placeholders = observables.get_placeholders(
             observable_df,

--- a/petab/problem.py
+++ b/petab/problem.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from math import nan
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Union
 from urllib.parse import unquote, urlparse, urlunparse
 from warnings import warn
 
@@ -76,7 +76,7 @@ class Problem:
         visualization_df: pd.DataFrame = None,
         observable_df: pd.DataFrame = None,
         mapping_df: pd.DataFrame = None,
-        extensions_config: Dict = None,
+        extensions_config: dict = None,
     ):
         self.condition_df: Optional[pd.DataFrame] = condition_df
         self.measurement_df: Optional[pd.DataFrame] = measurement_df
@@ -178,8 +178,8 @@ class Problem:
         ] = None,
         observable_files: Union[str, Path, Iterable[Union[str, Path]]] = None,
         model_id: str = None,
-        extensions_config: Dict = None,
-    ) -> "Problem":
+        extensions_config: dict = None,
+    ) -> Problem:
         """
         Factory method to load model and tables from files.
 
@@ -252,7 +252,7 @@ class Problem:
         )
 
     @staticmethod
-    def from_yaml(yaml_config: Union[Dict, Path, str]) -> "Problem":
+    def from_yaml(yaml_config: Union[dict, Path, str]) -> Problem:
         """
         Factory method to load model and tables as specified by YAML file.
 
@@ -274,9 +274,7 @@ class Problem:
             ):
                 # a regular file path string
                 path_prefix = Path(yaml_path).parent
-                get_path = (
-                    lambda filename: path_prefix / filename
-                )  # noqa: E731
+                get_path = lambda filename: path_prefix / filename  # noqa: E731
             else:
                 # a URL
                 # extract parent path from
@@ -293,9 +291,7 @@ class Problem:
                     )
                 )
                 # need "/" on windows, not "\"
-                get_path = (
-                    lambda filename: f"{path_prefix}/{filename}"
-                )  # noqa: E731
+                get_path = lambda filename: f"{path_prefix}/{filename}"  # noqa: E731
 
         if yaml.is_composite_problem(yaml_config):
             raise ValueError(
@@ -425,7 +421,7 @@ class Problem:
         )
 
     @staticmethod
-    def from_combine(filename: Union[Path, str]) -> "Problem":
+    def from_combine(filename: Union[Path, str]) -> Problem:
         """Read PEtab COMBINE archive (http://co.mbine.org/documents/archive).
 
         See also :py:func:`petab.create_combine_archive`.
@@ -687,7 +683,7 @@ class Problem:
         """
         return list(self.observable_df.index)
 
-    def _apply_mask(self, v: List, free: bool = True, fixed: bool = True):
+    def _apply_mask(self, v: list, free: bool = True, fixed: bool = True):
         """Apply mask of only free or only fixed values.
 
         Parameters
@@ -731,17 +727,17 @@ class Problem:
         return self._apply_mask(v, free=free, fixed=fixed)
 
     @property
-    def x_ids(self) -> List[str]:
+    def x_ids(self) -> list[str]:
         """Parameter table parameter IDs"""
         return self.get_x_ids()
 
     @property
-    def x_free_ids(self) -> List[str]:
+    def x_free_ids(self) -> list[str]:
         """Parameter table parameter IDs, for free parameters."""
         return self.get_x_ids(fixed=False)
 
     @property
-    def x_fixed_ids(self) -> List[str]:
+    def x_fixed_ids(self) -> list[str]:
         """Parameter table parameter IDs, for fixed parameters."""
         return self.get_x_ids(free=False)
 
@@ -777,35 +773,37 @@ class Problem:
         return self._apply_mask(v, free=free, fixed=fixed)
 
     @property
-    def x_nominal(self) -> List:
+    def x_nominal(self) -> list:
         """Parameter table nominal values"""
         return self.get_x_nominal()
 
     @property
-    def x_nominal_free(self) -> List:
+    def x_nominal_free(self) -> list:
         """Parameter table nominal values, for free parameters."""
         return self.get_x_nominal(fixed=False)
 
     @property
-    def x_nominal_fixed(self) -> List:
+    def x_nominal_fixed(self) -> list:
         """Parameter table nominal values, for fixed parameters."""
         return self.get_x_nominal(free=False)
 
     @property
-    def x_nominal_scaled(self) -> List:
+    def x_nominal_scaled(self) -> list:
         """Parameter table nominal values with applied parameter scaling"""
         return self.get_x_nominal(scaled=True)
 
     @property
-    def x_nominal_free_scaled(self) -> List:
+    def x_nominal_free_scaled(self) -> list:
         """Parameter table nominal values with applied parameter scaling,
-        for free parameters."""
+        for free parameters.
+        """
         return self.get_x_nominal(fixed=False, scaled=True)
 
     @property
-    def x_nominal_fixed_scaled(self) -> List:
+    def x_nominal_fixed_scaled(self) -> list:
         """Parameter table nominal values with applied parameter scaling,
-        for fixed parameters."""
+        for fixed parameters.
+        """
         return self.get_x_nominal(free=False, scaled=True)
 
     def get_lb(
@@ -836,12 +834,12 @@ class Problem:
         return self._apply_mask(v, free=free, fixed=fixed)
 
     @property
-    def lb(self) -> List:
+    def lb(self) -> list:
         """Parameter table lower bounds."""
         return self.get_lb()
 
     @property
-    def lb_scaled(self) -> List:
+    def lb_scaled(self) -> list:
         """Parameter table lower bounds with applied parameter scaling"""
         return self.get_lb(scaled=True)
 
@@ -873,23 +871,23 @@ class Problem:
         return self._apply_mask(v, free=free, fixed=fixed)
 
     @property
-    def ub(self) -> List:
+    def ub(self) -> list:
         """Parameter table upper bounds"""
         return self.get_ub()
 
     @property
-    def ub_scaled(self) -> List:
+    def ub_scaled(self) -> list:
         """Parameter table upper bounds with applied parameter scaling"""
         return self.get_ub(scaled=True)
 
     @property
-    def x_free_indices(self) -> List[int]:
+    def x_free_indices(self) -> list[int]:
         """Parameter table estimated parameter indices."""
         estimated = list(self.parameter_df[ESTIMATE])
         return [j for j, val in enumerate(estimated) if val != 0]
 
     @property
-    def x_fixed_indices(self) -> List[int]:
+    def x_fixed_indices(self) -> list[int]:
         """Parameter table non-estimated parameter indices."""
         estimated = list(self.parameter_df[ESTIMATE])
         return [j for j, val in enumerate(estimated) if val == 0]
@@ -941,7 +939,7 @@ class Problem:
 
     def sample_parameter_startpoints_dict(
         self, n_starts: int = 100
-    ) -> List[Dict[str, float]]:
+    ) -> list[dict[str, float]]:
         """Create dictionaries with starting points for optimization
 
         See also :py:func:`petab.sample_parameter_startpoints`.
@@ -959,8 +957,8 @@ class Problem:
 
     def unscale_parameters(
         self,
-        x_dict: Dict[str, float],
-    ) -> Dict[str, float]:
+        x_dict: dict[str, float],
+    ) -> dict[str, float]:
         """Unscale parameter values.
 
         Parameters
@@ -983,8 +981,8 @@ class Problem:
 
     def scale_parameters(
         self,
-        x_dict: Dict[str, float],
-    ) -> Dict[str, float]:
+        x_dict: dict[str, float],
+    ) -> dict[str, float]:
         """Scale parameter values.
 
         Parameters

--- a/petab/sbml.py
+++ b/petab/sbml.py
@@ -39,7 +39,6 @@ def is_sbml_consistent(
     Returns:
         ``False`` if problems were detected, otherwise ``True``
     """
-
     if not check_units:
         sbml_document.setConsistencyChecks(
             libsbml.LIBSBML_CAT_UNITS_CONSISTENCY, False
@@ -202,7 +201,6 @@ def load_sbml_from_string(
     :param sbml_string: Model as XML string
     :return: The SBML document, model and reader
     """
-
     sbml_reader = libsbml.SBMLReader()
     sbml_document = sbml_reader.readSBMLFromString(sbml_string)
     sbml_model = sbml_document.getModel()

--- a/petab/simplify.py
+++ b/petab/simplify.py
@@ -63,7 +63,8 @@ def simplify_problem(problem: Problem):
 
 def condition_parameters_to_parameter_table(problem: Problem):
     """Move parameters from the condition table to the parameters table, if
-    the same parameter value is used for all conditions."""
+    the same parameter value is used for all conditions.
+    """
     if (
         problem.condition_df is None
         or problem.condition_df.empty

--- a/petab/visualize/__init__.py
+++ b/petab/visualize/__init__.py
@@ -15,17 +15,6 @@ from .plotting import DataProvider, Figure
 __all__ = ["DataProvider", "Figure"]
 
 if mpl_spec is not None:
-    from .plot_data_and_simulation import (
-        plot_problem,
-        plot_with_vis_spec,
-        plot_without_vis_spec,
-    )
-    from .plot_residuals import (
-        plot_goodness_of_fit,
-        plot_residuals_vs_simulation,
-    )
-    from .plotter import MPLPlotter
-
     __all__.extend(
         [
             "plot_without_vis_spec",

--- a/petab/visualize/__init__.py
+++ b/petab/visualize/__init__.py
@@ -6,15 +6,25 @@ PEtab comes with visualization functionality. Those need to be imported via
 ``import petab.visualize``.
 
 """
+# ruff: noqa: F401
 import importlib.util
-
-mpl_spec = importlib.util.find_spec("matplotlib")
 
 from .plotting import DataProvider, Figure
 
 __all__ = ["DataProvider", "Figure"]
 
-if mpl_spec is not None:
+if importlib.util.find_spec("matplotlib") is not None:
+    from .plot_data_and_simulation import (
+        plot_problem,
+        plot_with_vis_spec,
+        plot_without_vis_spec,
+    )
+    from .plot_residuals import (
+        plot_goodness_of_fit,
+        plot_residuals_vs_simulation,
+    )
+    from .plotter import MPLPlotter
+
     __all__.extend(
         [
             "plot_without_vis_spec",

--- a/petab/visualize/cli.py
+++ b/petab/visualize/cli.py
@@ -10,7 +10,6 @@ from .plot_data_and_simulation import plot_problem
 
 def _parse_cli_args():
     """Parse command-line arguments."""
-
     parser = argparse.ArgumentParser(
         description="Create PEtab visualizations."
     )

--- a/petab/visualize/data_overview.py
+++ b/petab/visualize/data_overview.py
@@ -24,7 +24,6 @@ def create_report(
         model_name: Name of the model, used for file name for report
         output_path: Output directory
     """
-
     template_dir = Path(__file__).absolute().parent / "templates"
     output_path = Path(output_path)
     template_file = "report.html"
@@ -59,7 +58,6 @@ def get_data_per_observable(measurement_df: pd.DataFrame) -> pd.DataFrame:
     Returns:
         Pivot table with number of data points per observable and condition
     """
-
     my_measurements = measurement_df.copy()
 
     index = [SIMULATION_CONDITION_ID]

--- a/petab/visualize/helper_functions.py
+++ b/petab/visualize/helper_functions.py
@@ -33,7 +33,6 @@ def generate_dataset_id_col(exp_data: pd.DataFrame) -> List[str]:
         A list with generated datasetIds for each entry in the measurement
         (simulation) DataFrame
     """
-
     # create a column of dummy datasetIDs and legend entries: preallocate
     dataset_id_column = []
 

--- a/petab/visualize/plot_data_and_simulation.py
+++ b/petab/visualize/plot_data_and_simulation.py
@@ -1,5 +1,6 @@
 """Functions for plotting PEtab measurement files and simulation results in
-the same format."""
+the same format.
+"""
 
 from typing import Dict, List, Optional, Union
 
@@ -58,7 +59,6 @@ def plot_with_vis_spec(
     ax: Axis object of the created plot.
     None: In case subplots are saved to a file.
     """
-
     if measurements_df is None and simulations_df is None:
         raise TypeError(
             "Not enough arguments. Either measurements_data "
@@ -133,7 +133,6 @@ def plot_without_vis_spec(
     ax: Axis object of the created plot.
     None: In case subplots are saved to a file.
     """
-
     if measurements_df is None and simulations_df is None:
         raise TypeError(
             "Not enough arguments. Either measurements_data "
@@ -203,7 +202,6 @@ def plot_problem(
     ax: Axis object of the created plot.
     None: In case subplots are saved to a file.
     """
-
     if petab_problem.visualization_df is not None:
         return plot_with_vis_spec(
             petab_problem.visualization_df,

--- a/petab/visualize/plot_residuals.py
+++ b/petab/visualize/plot_residuals.py
@@ -155,7 +155,6 @@ def plot_goodness_of_fit(
     -------
         ax: Axis object of the created plot.
     """
-
     if isinstance(simulations_df, (str, Path)):
         simulations_df = get_simulation_df(simulations_df)
 

--- a/petab/visualize/plotter.py
+++ b/petab/visualize/plotter.py
@@ -22,7 +22,6 @@ class Plotter(ABC):
 
     Attributes
     ----------
-
     figure:
         Figure instance that serves as a markup for the figure that
         should be generated
@@ -125,12 +124,7 @@ class MPLPlotter(Plotter):
                 )
                 # sorts according to ascending order of conditions
                 cond, replicates = zip(
-                    *sorted(
-                        zip(
-                            measurements_to_plot.conditions,
-                            replicates
-                        )
-                    )
+                    *sorted(zip(measurements_to_plot.conditions, replicates))
                 )
                 replicates = np.stack(replicates)
 
@@ -448,7 +442,7 @@ class MPLPlotter(Plotter):
 
         # show 'e' as basis not 2.7... in natural log scale cases
         def ticks(y, _):
-            return r"$e^{{{:.0f}}}$".format(np.log(y))
+            return rf"$e^{{{np.log(y):.0f}}}$"
 
         if subplot.xScale == LOG:
             ax.xaxis.set_major_formatter(mtick.FuncFormatter(ticks))
@@ -547,7 +541,6 @@ class MPLPlotter(Plotter):
         -------
             Updated axis object.
         """
-
         ax.axis("square")
 
         if lim is None:

--- a/petab/visualize/plotting.py
+++ b/petab/visualize/plotting.py
@@ -122,7 +122,6 @@ class DataPlot:
         plot_settings: A plot spec for one dataplot
             (only VISUALIZATION_DF_SINGLE_PLOT_LEVEL_COLS)
         """
-
         for key, val in plot_settings.items():
             setattr(self, key, val)
 
@@ -307,7 +306,6 @@ class Figure:
         size: Figure size
         title: Figure title
         """
-
         # TODO: Isensee measurements table in doc/examples doesn't correspond
         #       to documentation: observableTransformation and
         #       noiseDistribution columns replicateId problem
@@ -351,7 +349,6 @@ class Figure:
         ylim:
             Y axis limits.
         """
-
         for subplot in self.subplots:
             subplot.set_axes_limits(xlim, ylim)
 
@@ -496,7 +493,6 @@ class DataProvider:
             uni_condition_id
 
         """
-
         indep_var = getattr(dataplot, X_VALUES)
 
         dataset_id = getattr(dataplot, DATASET_ID)
@@ -726,7 +722,6 @@ class VisSpecParser:
 
         Returns
         -------
-
                 Subplot
         """
         subplot_columns = [
@@ -766,7 +761,6 @@ class VisSpecParser:
 
         Returns
         -------
-
         A figure template with visualization settings and a data provider
         """
         # import visualization specification, if file was specified
@@ -858,7 +852,6 @@ class VisSpecParser:
         A figure template with visualization settings and a data provider
 
         """
-
         if ids_per_plot is None:
             # this is the default case. If no grouping is specified,
             # all observables are plotted. One observable per plot.
@@ -893,7 +886,6 @@ class VisSpecParser:
         Add dataset_id column to the measurement table and simulations table
         (possibly overwrite).
         """
-
         if self.measurements_data is not None:
             if DATASET_ID in self.measurements_data.columns:
                 self.measurements_data = self.measurements_data.drop(
@@ -938,7 +930,6 @@ class VisSpecParser:
         A dictionary with values for columns PLOT_ID, DATASET_ID, \
         LEGEND_ENTRY, Y_VALUES for visualization specification.
         """
-
         if group_by != "dataset":
             dataset_id_list = create_dataset_id_list_new(
                 self._data_df, group_by, id_list

--- a/petab/yaml.py
+++ b/petab/yaml.py
@@ -46,7 +46,6 @@ def validate(
             file if a filename was provided for ``yaml_config`` or the current
             working directory.
     """
-
     validate_yaml_syntax(yaml_config)
     validate_yaml_semantics(yaml_config=yaml_config, path_prefix=path_prefix)
 
@@ -157,7 +156,6 @@ def load_yaml(yaml_config: Union[Dict, Path, str]) -> Dict:
         The unmodified dictionary if ``yaml_config`` was dictionary.
         Otherwise the parsed the YAML file.
     """
-
     # already parsed? all PEtab problem yaml files are dictionaries
     if isinstance(yaml_config, dict):
         return yaml_config
@@ -173,7 +171,6 @@ def is_composite_problem(yaml_config: Union[Dict, str, Path]) -> bool:
     Arguments:
         yaml_config: PEtab configuration as dictionary or YAML file name
     """
-
     yaml_config = load_yaml(yaml_config)
     return len(yaml_config[PROBLEMS]) > 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,21 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 80
+[tool.ruff]
+line-length = 79
+lint.extend-select = [
+    "F",  # Pyflakes
+    "I",  # isort
+    "S",  # flake8-bandit
+    "B",  # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "T20",  # flake8-print
+    "W",  # pycodestyle Warnings
+    "E",  # pycodestyle Errors
+    "UP",  # pyupgrade
+    # TODO: "ANN001", "D",  # pydocstyle (PEP 257)
+]
+lint.extend-ignore = ["F403", "F405", "S101"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ def read(fname):
 
 def absolute_links(txt):
     """Replace relative petab github links by absolute links."""
-
     raw_base = (
         "(https://raw.githubusercontent.com/petab-dev/libpetab-python/master/"
     )

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -15,7 +15,6 @@ pytest_plugins = [
 
 def test_combine_archive():
     """Test `create_combine_archive` and `Problem.from_combine`"""
-
     # Create test files
     import simplesbml
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -425,7 +425,8 @@ def test_assert_parameter_prior_parameters_are_valid():
 
 def test_petablint_succeeds():
     """Run petablint and ensure we exit successfully for a file that should
-    contain no errors"""
+    contain no errors
+    """
     dir_isensee = "../doc/example/example_Isensee/"
     dir_fujita = "../doc/example/example_Fujita/"
 
@@ -550,7 +551,6 @@ def test_check_condition_df():
 
 def test_check_ids():
     """Test check_ids"""
-
     lint.check_ids(["a1", "_1"])
 
     with pytest.raises(ValueError):
@@ -559,7 +559,6 @@ def test_check_ids():
 
 def test_check_parameter_df():
     """Check lint.check_parameter_df."""
-
     parameter_df = pd.DataFrame(
         {
             PARAMETER_ID: ["par0", "par1", "par2"],
@@ -586,7 +585,6 @@ def test_check_parameter_df():
 
 def test_check_observable_df():
     """Check that we correctly detect errors in observable table"""
-
     observable_df = pd.DataFrame(
         data={
             OBSERVABLE_ID: ["obs1", "obs2"],

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -77,7 +77,6 @@ def test_measurements_have_replicates():
 
 def test_get_simulation_conditions():
     """Test get_simulation_conditions"""
-
     # only simulation condition
     measurement_df = pd.DataFrame(
         data={

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -114,7 +114,6 @@ def test_get_output_parameters():
 
 def test_get_formula_placeholders():
     """Test get_formula_placeholders"""
-
     # no placeholder
     assert petab.get_formula_placeholders("1.0", "any", "observable") == []
 

--- a/tests/test_parameter_mapping.py
+++ b/tests/test_parameter_mapping.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 ]
 
 
-class TestGetSimulationToOptimizationParameterMapping(object):
+class TestGetSimulationToOptimizationParameterMapping:
     @staticmethod
     def test_no_condition_specific(condition_df_2_conditions):
         # Trivial case - no condition-specific parameters
@@ -544,8 +544,8 @@ class TestGetSimulationToOptimizationParameterMapping(object):
         - a log10 parameter to be estimated (condition 1)
         - lin parameter not estimated (condition2)
         - log10 parameter not estimated (condition 3)
-        - constant override (condition 4)"""
-
+        - constant override (condition 4)
+        """
         # overridden parameter
         overridee_id = "overridee"
 

--- a/tests/test_petab.py
+++ b/tests/test_petab.py
@@ -766,7 +766,6 @@ def test_to_files(petab_problem):  # pylint: disable=W0621
 
 def test_load_remote():
     """Test loading remote files"""
-
     yaml_url = (
         "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
         "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
@@ -797,7 +796,8 @@ def test_problem_from_yaml_v1_empty():
 
 def test_problem_from_yaml_v1_multiple_files():
     """Test loading PEtab version 1 yaml with multiple condition / measurement
-    / observable files"""
+    / observable files
+    """
     yaml_config = """
     format_version: 1
     parameter_file:

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -138,7 +138,6 @@ def test_zero_bounded(petab_problem):
 
 def test_add_noise(petab_problem):
     """Test the noise generating method."""
-
     tested_noise_distributions = {"normal", "laplace"}
     assert set(petab.C.NOISE_MODELS) == tested_noise_distributions, (
         "The noise generation methods have only been tested for "


### PR DESCRIPTION
Instead of black and isort, run ruff as pre-commit hook. Enable pyupgrade and additional rules.

Applied safe auto-fixes, but validation currently fails. Will be addressed in a follow-up PR (#252).

Relevant changes: `.pre-commit-config.yaml`, `pyproject.toml`