### PR TITLE
Require python>=3.10

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.10", "3.12"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ sphinx:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
    install:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and the easiest way to install it is running
 
     pip3 install petab
 
-It will require Python>=3.9 to run. (We are following the
+It will require Python>=3.10 to run. (We are following the
 [numpy Python support policy](https://numpy.org/neps/nep-0029-deprecation_policy.html)).
 
 Development versions of the PEtab library can be installed using
@@ -57,7 +57,7 @@ Examples for PEtab Python library usage:
 
 ## Getting help
 
-If you have any question or problems with this package, feel free to post them
+If you have any questions or problems with this package, feel free to post them
 at our GitHub [issue tracker](https://github.com/PEtab-dev/libpetab-python/issues/).
 
 ## Contributing

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import re
-import sys
 
 from setuptools import find_namespace_packages, setup
 
@@ -29,10 +28,6 @@ def absolute_links(txt):
         txt = txt.replace(var, rep)
     return txt
 
-
-# Python version check
-if sys.version_info < (3, 9, 0):
-    sys.exit("PEtab requires at least Python version 3.9")
 
 # read version from file
 __version__ = ""
@@ -72,7 +67,7 @@ setup(
         "jsonschema",
     ],
     include_package_data=True,
-    python_requires=">=3.9.0",
+    python_requires=">=3.10.0",
     entry_points=ENTRY_POINTS,
     extras_require={
         "tests": [


### PR DESCRIPTION
Require python>=3.10 according to [NEP-0029](https://numpy.org/neps/nep-0029-deprecation_policy.html#drop-schedule).