### PR TITLE
Require positive bounds for log-scale parameters

### DIFF
--- a/petab/lint.py
+++ b/petab/lint.py
@@ -547,7 +547,7 @@ def check_parameter_bounds(parameter_df: pd.DataFrame) -> None:
                     f"{LOWER_BOUND} greater than {UPPER_BOUND} for "
                     f"{PARAMETER_ID} {row.name}."
                 )
-            if (row[LOWER_BOUND] < 0.0 or row[UPPER_BOUND] < 0.0) and row[
+            if (row[LOWER_BOUND] <= 0.0 or row[UPPER_BOUND] <= 0.0) and row[
                 PARAMETER_SCALE
             ] in [LOG, LOG10]:
                 raise AssertionError(


### PR DESCRIPTION
Previously, bounds were only checked for non-negativity.