### PR TITLE
PEtab v1 to v2 converter

### DIFF
--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -10,7 +10,8 @@ from petab.models import MODEL_TYPE_SBML
 from petab.v2.lint import lint_problem as lint_v2_problem
 from petab.yaml import get_path_prefix
 
-from .. import lint_problem
+from .. import lint_problem as lint_v1_problem
+from ..versions import get_major_version
 from ..yaml import load_yaml, validate, write_yaml
 
 __all__ = ["petab1to2"]
@@ -55,11 +56,10 @@ def petab1to2(yaml_config: Path | str, output_dir: Path | str = None):
 
     # Validate original PEtab problem
     validate(yaml_config, path_prefix=path_prefix)
-    if str(yaml_config[petab.C.FORMAT_VERSION]) != "1":
-        # TODO: Other valid version numbers?
+    if get_major_version(yaml_config) != 1:
         raise ValueError("PEtab problem is not version 1.")
     petab_problem = petab.Problem.from_yaml(yaml_file or yaml_config)
-    if lint_problem(petab_problem):
+    if lint_v1_problem(petab_problem):
         raise ValueError("PEtab problem does not pass linting.")
 
     # Update YAML file

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -1,0 +1,146 @@
+"""Convert PEtab version 1 problems to version 2."""
+import shutil
+from itertools import chain
+from pathlib import Path
+
+from pandas.io.common import get_handle, is_url
+
+import petab.C
+from petab.models import MODEL_TYPE_SBML
+from petab.v2.lint import lint_problem as lint_v2_problem
+from petab.yaml import get_path_prefix
+
+from .. import lint_problem
+from ..yaml import load_yaml, validate, write_yaml
+
+__all__ = ["petab1to2"]
+
+
+def petab1to2(yaml_config: Path | str, output_dir: Path | str = None):
+    """Convert from PEtab 1.0 to PEtab 2.0 format.
+
+    Convert a PEtab problem from PEtab 1.0 to PEtab 2.0 format.
+
+    Parameters
+    ----------
+    yaml_config: dict | Path | str
+        The PEtab problem as dictionary or YAML file name.
+    output_dir: Path | str
+        The output directory to save the converted PEtab problem, or ``None``,
+        to return a :class:`petab.v2.Problem` instance.
+
+    Raises
+    ------
+    ValueError
+        If the input is invalid or does not pass linting or if the generated
+        files do not pass linting.
+    """
+    if output_dir is None:
+        # TODO requires petab.v2.Problem
+        raise NotImplementedError("Not implemented yet.")
+    elif isinstance(yaml_config, dict):
+        raise ValueError("If output_dir is given, yaml_config must be a file.")
+
+    if isinstance(yaml_config, Path | str):
+        yaml_file = str(yaml_config)
+        path_prefix = get_path_prefix(yaml_file)
+        yaml_config = load_yaml(yaml_config)
+        get_src_path = lambda filename: f"{path_prefix}/{filename}"  # noqa: E731
+    else:
+        yaml_file = None
+        path_prefix = None
+        get_src_path = lambda filename: filename  # noqa: E731
+
+    get_dest_path = lambda filename: f"{output_dir}/{filename}"  # noqa: E731
+
+    # Validate original PEtab problem
+    validate(yaml_config, path_prefix=path_prefix)
+    if str(yaml_config[petab.C.FORMAT_VERSION]) != "1":
+        # TODO: Other valid version numbers?
+        raise ValueError("PEtab problem is not version 1.")
+    petab_problem = petab.Problem.from_yaml(yaml_file or yaml_config)
+    if lint_problem(petab_problem):
+        raise ValueError("PEtab problem does not pass linting.")
+
+    # Update YAML file
+    new_yaml_config = _update_yaml(yaml_config)
+
+    # Write new YAML file
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    new_yaml_file = output_dir / Path(yaml_file).name
+    write_yaml(new_yaml_config, new_yaml_file)
+
+    # Update tables
+    # condition tables, observable tables, SBML files, parameter table:
+    #  no changes - just copy
+    file = yaml_config[petab.C.PARAMETER_FILE]
+    _copy_file(get_src_path(file), get_dest_path(file))
+
+    for problem_config in yaml_config[petab.C.PROBLEMS]:
+        for file in chain(
+            problem_config.get(petab.C.CONDITION_FILES, []),
+            problem_config.get(petab.C.OBSERVABLE_FILES, []),
+            (
+                model[petab.C.MODEL_LOCATION]
+                for model in problem_config.get(
+                    petab.C.MODEL_FILES, {}
+                ).values()
+            ),
+            problem_config.get(petab.C.MEASUREMENT_FILES, []),
+            problem_config.get(petab.C.VISUALIZATION_FILES, []),
+        ):
+            _copy_file(get_src_path(file), get_dest_path(file))
+
+    # TODO: Measurements: preequilibration to experiments/timecourses once
+    #  finalized
+    ...
+
+    # validate updated Problem
+    validation_issues = lint_v2_problem(new_yaml_file)
+
+    if validation_issues:
+        raise ValueError(
+            "Generated PEtab v2 problem did not pass linting: "
+            f"{validation_issues}"
+        )
+
+
+def _update_yaml(yaml_config: dict) -> dict:
+    """Update PEtab 1.0 YAML to PEtab 2.0 format."""
+    yaml_config = yaml_config.copy()
+
+    # Update format_version
+    yaml_config[petab.C.FORMAT_VERSION] = "2.0.0"
+
+    # Add extensions
+    yaml_config[petab.C.EXTENSIONS] = []
+
+    # Move models and set IDs (filename for now)
+    for problem in yaml_config[petab.C.PROBLEMS]:
+        problem[petab.C.MODEL_FILES] = {}
+        models = problem[petab.C.MODEL_FILES]
+        for sbml_file in problem[petab.C.SBML_FILES]:
+            model_id = sbml_file.split("/")[-1].split(".")[0]
+            models[model_id] = {
+                petab.C.MODEL_LANGUAGE: MODEL_TYPE_SBML,
+                petab.C.MODEL_LOCATION: sbml_file,
+            }
+            problem[petab.C.MODEL_FILES] = problem.get(petab.C.MODEL_FILES, {})
+        del problem[petab.C.SBML_FILES]
+
+    return yaml_config
+
+
+def _copy_file(src: Path | str, dest: Path | str):
+    """Copy file."""
+    src = str(src)
+    dest = str(dest)
+
+    if is_url(src):
+        with get_handle(src, mode="r") as src_handle:
+            with open(dest, "w") as dest_handle:
+                dest_handle.write(src_handle.handle.read())
+        return
+
+    shutil.copy(str(src), str(dest))

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 from math import nan
@@ -125,13 +126,37 @@ class Problem:
         if isinstance(yaml_config, Path):
             yaml_config = str(yaml_config)
 
-        get_path = lambda filename: filename  # noqa: E731
         if isinstance(yaml_config, str):
-            path_prefix = get_path_prefix(yaml_config)
+            yaml_file = yaml_config
+            path_prefix = get_path_prefix(yaml_file)
             yaml_config = yaml.load_yaml(yaml_config)
             get_path = lambda filename: f"{path_prefix}/{filename}"  # noqa: E731
+        else:
+            yaml_file = None
+            get_path = lambda filename: filename  # noqa: E731
 
         if yaml_config[FORMAT_VERSION] not in {"2.0.0"}:
+            # If we got a path to a v1 yaml file, try to auto-upgrade
+            from tempfile import TemporaryDirectory
+
+            from ..versions import get_major_version
+            from .petab1to2 import petab1to2
+
+            if get_major_version(yaml_config) == 1 and yaml_file:
+                logging.debug(
+                    "Auto-upgrading problem from PEtab 1.0 to PEtab 2.0"
+                )
+                with TemporaryDirectory() as tmpdirname:
+                    try:
+                        petab1to2(yaml_file, output_dir=tmpdirname)
+                    except Exception as e:
+                        raise ValueError(
+                            "Failed to auto-upgrade PEtab 1.0 problem to "
+                            "PEtab 2.0"
+                        ) from e
+                    return Problem.from_yaml(
+                        Path(tmpdirname) / Path(yaml_file).name
+                    )
             raise ValueError(
                 "Provided PEtab files are of unsupported version "
                 f"{yaml_config[FORMAT_VERSION]}. Expected 2.0.0."

--- a/tests/v2/test_conversion.py
+++ b/tests/v2/test_conversion.py
@@ -1,0 +1,32 @@
+import logging
+import tempfile
+
+from petab.v2.petab1to2 import petab1to2
+
+
+def test_petab1to2_remote():
+    yaml_url = (
+        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
+        "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="test_petab1to2") as tmpdirname:
+        petab1to2(yaml_url, tmpdirname)
+
+
+def test_benchmark_collection():
+    """Test that we can upgrade all benchmark collection models."""
+    import benchmark_models_petab
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    for problem_id in benchmark_models_petab.MODELS:
+        if problem_id == "Lang_PLOSComputBiol2024":
+            # Does not pass initial linting
+            continue
+
+        yaml_path = benchmark_models_petab.get_problem_yaml_path(problem_id)
+        with tempfile.TemporaryDirectory(
+            prefix=f"test_petab1to2_{problem_id}"
+        ) as tmpdirname:
+            petab1to2(yaml_path, tmpdirname)

--- a/tests/v2/test_conversion.py
+++ b/tests/v2/test_conversion.py
@@ -11,6 +11,8 @@ def test_petab1to2_remote():
     )
 
     with tempfile.TemporaryDirectory(prefix="test_petab1to2") as tmpdirname:
+        # TODO verify that the v2 files match "ground truth"
+        # in `petabtests/cases/v2.0.0/sbml/0001/_0001.yaml`
         petab1to2(yaml_url, tmpdirname)
 
 

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -23,4 +23,5 @@ def test_auto_upgrade():
         "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
     )
     problem = Problem.from_yaml(yaml_url)
+    # TODO check something specifically different in a v2 problem
     assert isinstance(problem, Problem)

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -1,5 +1,3 @@
-import pytest
-
 from petab.v2 import Problem
 
 
@@ -18,8 +16,11 @@ def test_load_remote():
 
     assert petab_problem.validate() == []
 
-    yaml_url = yaml_url.replace("2.0.0", "1.0.0")
-    with pytest.raises(
-        ValueError, match="Provided PEtab files are of unsupported version"
-    ):
-        Problem.from_yaml(yaml_url)
+
+def test_auto_upgrade():
+    yaml_url = (
+        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
+        "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
+    )
+    problem = Problem.from_yaml(yaml_url)
+    assert isinstance(problem, Problem)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,9 @@ description =
 
 [testenv:unit]
 extras = tests,reports,combine,vis
-deps=git+https://github.com/PEtab-dev/petab_test_suite@math_tests
+deps=
+  git+https://github.com/PEtab-dev/petab_test_suite@math_tests
+  git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
 
 commands =
   python -m pip install sympy>=1.12.1


### PR DESCRIPTION
Converter for PEtab v1 problems to PEtab v2 problems. 

Allows converting a set of PEtab v1 files to v2 files or creating a petab.v2.Problem from v1 yaml file.



To be extended/adapted as v2 matures.

Closes #272.