### PR TITLE
New validation API

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -28,3 +28,6 @@ API Reference
    petab.v1.simplify
    petab.v1.visualize
    petab.v1.yaml
+   petab.v2
+   petab.v2.lint
+   petab.v2.problem

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -321,7 +321,7 @@ class ValidationEventLevel(IntEnum):
     CRITICAL = 40
 
 
-default_validation_taks = [
+default_validation_tasks = [
     ModelValidationTask(),
     MeasurementTableValidationTask(),
     ConditionTableValidationTask(),

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -115,7 +115,10 @@ class ValidationResultList(list[ValidationIssue]):
     """
 
     def log(
-        self, min_level: ValidationIssueSeverity = ValidationIssueSeverity.INFO
+        self,
+        *,
+        logger: logging.Logger = logger,
+        min_level: ValidationIssueSeverity = ValidationIssueSeverity.INFO,
     ):
         """Log the validation results."""
         for result in self:

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -97,6 +97,12 @@ class ValidationIssue:
     level: ValidationIssueSeverity
     message: str
 
+    def __post_init__(self):
+        if not isinstance(self.level, ValidationIssueSeverity):
+            raise TypeError(
+                "`level` must be an instance of ValidationIssueSeverity."
+            )
+
     def __str__(self):
         return f"{self.level.name}: {self.message}"
 
@@ -314,8 +320,9 @@ class CheckParameterTable(ValidationTask):
                     )
                 ]
             )
-            # TODO implement as validators `assert_has_fixed_parameter_nominal_values`
-            # and `assert_correct_table_dtypes`
+            # TODO implement as validators
+            #  `assert_has_fixed_parameter_nominal_values`
+            #   and `assert_correct_table_dtypes`
             if non_estimated_par_ids:
                 if NOMINAL_VALUE not in df:
                     return ValidationError(

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -1,0 +1,331 @@
+"""Validation of PEtab problems"""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+
+from .problem import Problem
+
+logger = logging.getLogger(__name__)
+
+
+def lint_problem(problem: Problem | str | Path) -> ValidationResultList:
+    """Validate a PEtab problem.
+
+    Arguments:
+        problem: PEtab problem to check. Instance of :class:`Problem` or path
+        to a PEtab problem yaml file.
+    """
+
+    if isinstance(problem, str | Path):
+        problem = Problem.from_yaml(str(problem))
+
+    return problem.validate()
+
+
+class ValidationTask(ABC):
+    """A task to validate a PEtab problem."""
+
+    @abstractmethod
+    def run(self, problem: Problem) -> list[ValidationResult]:
+        """Run the validation task.
+
+        Arguments:
+            problem: PEtab problem to check.
+        """
+        ...
+
+
+class ModelValidationTask(ValidationTask):
+    """A task to validate the model of a PEtab problem."""
+
+    def run(self, problem: Problem) -> list[ValidationResult]:
+        if problem.model is None:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.WARNING,
+                        message="Model is missing.",
+                    )
+                ]
+            )
+
+        if problem.model.is_valid():
+            return []
+
+        return ValidationResultList(
+            [
+                ValidationResult(
+                    level=ValidationEventLevel.ERROR,
+                    message="Model is invalid.",
+                )
+            ]
+        )
+
+
+class MeasurementTableValidationTask(ValidationTask):
+    """A task to validate the measurement table of a PEtab problem."""
+
+    def run(self, problem: Problem) -> list[ValidationResult]:
+        if problem.measurement_df is None or problem.measurement_df.empty:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR,
+                        message="Measurement table is missing or empty.",
+                    )
+                ]
+            )
+
+        try:
+            from ..v1 import (
+                assert_measurement_conditions_present_in_condition_table,
+                check_measurement_df,
+            )
+
+            check_measurement_df(problem.measurement_df, problem.observable_df)
+
+            if problem.condition_df is not None:
+                assert_measurement_conditions_present_in_condition_table(
+                    problem.measurement_df, problem.condition_df
+                )
+        except AssertionError as e:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR, message=str(e)
+                    )
+                ]
+            )
+        return []
+
+
+class ConditionTableValidationTask(ValidationTask):
+    """A task to validate the condition table of a PEtab problem."""
+
+    def run(self, problem: Problem) -> list[ValidationResult]:
+        if problem.condition_df is None or problem.condition_df.empty:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR,
+                        message="Condition table is missing or empty.",
+                    )
+                ]
+            )
+
+        try:
+            from ..v1 import check_condition_df
+
+            check_condition_df(
+                problem.condition_df,
+                model=problem.model,
+                observable_df=problem.observable_df,
+                mapping_df=problem.mapping_df,
+            )
+        except AssertionError as e:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR, message=str(e)
+                    )
+                ]
+            )
+        return []
+
+
+class ObservableTableValidationTask(ValidationTask):
+    """A task to validate the observable table of a PEtab problem."""
+
+    def run(self, problem: Problem):
+        if problem.observable_df is None or problem.observable_df.empty:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR,
+                        message="Observable table is missing or empty.",
+                    )
+                ]
+            )
+
+        try:
+            from ..v1 import check_observable_df
+
+            check_observable_df(
+                problem.observable_df,
+            )
+        except AssertionError as e:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR, message=str(e)
+                    )
+                ]
+            )
+        result = ValidationResultList()
+        if problem.model is not None:
+            for obs_id in problem.observable_df.index:
+                if problem.model.has_entity_with_id(obs_id):
+                    result.append(
+                        ValidationResult(
+                            level=ValidationEventLevel.ERROR,
+                            message=f"Observable ID {obs_id} shadows model "
+                            "entity.",
+                        )
+                    )
+        return result
+
+
+class ParameterTableValidationTask(ValidationTask):
+    """A task to validate the parameter table of a PEtab problem."""
+
+    def run(self, problem: Problem) -> list[ValidationResult]:
+        if problem.parameter_df is None or problem.parameter_df.empty:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR,
+                        message="Parameter table is missing or empty.",
+                    )
+                ]
+            )
+
+        try:
+            from ..v1 import check_parameter_df
+
+            check_parameter_df(
+                problem.parameter_df,
+                problem.model,
+                problem.observable_df,
+                problem.measurement_df,
+                problem.condition_df,
+                problem.mapping_df,
+            )
+        except AssertionError as e:
+            return ValidationResultList(
+                [
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR, message=str(e)
+                    )
+                ]
+            )
+        return []
+
+
+class MiscValidationTask(ValidationTask):
+    """A task to perform miscellaneous validation checks."""
+
+    def run(self, problem: Problem):
+        result = ValidationResultList()
+        from petab.v1 import (
+            assert_model_parameters_in_condition_or_parameter_table,
+        )
+
+        if (
+            problem.model is not None
+            and problem.condition_df is not None
+            and problem.parameter_df is not None
+        ):
+            try:
+                assert_model_parameters_in_condition_or_parameter_table(
+                    problem.model,
+                    problem.condition_df,
+                    problem.parameter_df,
+                    problem.mapping_df,
+                )
+            except AssertionError as e:
+                result.append(
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR, message=str(e)
+                    )
+                )
+
+        if problem.visualization_df is not None:
+            from petab.visualize.lint import validate_visualization_df
+
+            # TODO: don't log directly
+            if validate_visualization_df(problem):
+                result.append(
+                    ValidationResult(
+                        level=ValidationEventLevel.ERROR,
+                        message="Visualization table is invalid.",
+                    )
+                )
+        else:
+            result.append(
+                ValidationResult(
+                    level=ValidationEventLevel.WARNING,
+                    message="Visualization table is missing.",
+                )
+            )
+
+        if (
+            problem.measurement_df is None
+            or problem.condition_df is None
+            or problem.model is None
+            or problem.parameter_df is None
+            or problem.observable_df is None
+        ):
+            result.append(
+                ValidationResult(
+                    level=ValidationEventLevel.WARNING,
+                    message="Not all files of the PEtab problem definition "
+                    "could be checked.",
+                )
+            )
+        return result
+
+
+@dataclass
+class ValidationResult:
+    """The result of a validation task."""
+
+    level: ValidationEventLevel
+    message: str
+
+
+class ValidationResultList(list[ValidationResult]):
+    """A list of validation results."""
+
+    def log(self, min_):
+        """Log the validation results."""
+        for result in self:
+            if result.level == ValidationEventLevel.INFO:
+                logger.info(result.message)
+            elif result.level == ValidationEventLevel.WARNING:
+                logger.warning(result.message)
+            elif result.level >= ValidationEventLevel.ERROR:
+                logger.error(result.message)
+
+        if not self:
+            logger.info("PEtab format check completed successfully.")
+
+    def has_errors(self) -> bool:
+        """Check if there are any errors in the validation results."""
+        return any(
+            result.level >= ValidationEventLevel.ERROR for result in self
+        )
+
+
+class ValidationEventLevel(IntEnum):
+    # INFO: Informational message, no action required
+    INFO = 10
+    # WARNING: Warning message, potential issues
+    WARNING = 20
+    # ERROR: Error message, action required
+    ERROR = 30
+    # CRITICAL: Critical error message, stops further validation
+    CRITICAL = 40
+
+
+default_validation_taks = [
+    ModelValidationTask(),
+    MeasurementTableValidationTask(),
+    ConditionTableValidationTask(),
+    ObservableTableValidationTask(),
+    ParameterTableValidationTask(),
+    MiscValidationTask(),
+]

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from pathlib import Path
 
@@ -107,11 +107,13 @@ class ValidationIssue:
         return f"{self.level.name}: {self.message}"
 
 
+@dataclass
 class ValidationError(ValidationIssue):
     """A validation result with level ERROR."""
 
-    def __init__(self, message: str):
-        super().__init__(ValidationIssueSeverity.ERROR, message)
+    level: ValidationIssueSeverity = field(
+        default=ValidationIssueSeverity.ERROR, init=False
+    )
 
 
 class ValidationResultList(list[ValidationIssue]):

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -304,8 +304,7 @@ class CheckParameterTable(ValidationTask):
                         df[column_name].values, column_name
                     )
 
-            # nominal value is generally optional, but required if any for any
-            #  parameter estimate != 1
+            # nominal value is required for non-estimated parameters
             non_estimated_par_ids = list(
                 df.index[
                     (df[ESTIMATE] != 1)
@@ -315,6 +314,8 @@ class CheckParameterTable(ValidationTask):
                     )
                 ]
             )
+            # TODO implement as validators `assert_has_fixed_parameter_nominal_values`
+            # and `assert_correct_table_dtypes`
             if non_estimated_par_ids:
                 if NOMINAL_VALUE not in df:
                     return ValidationError(

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -58,7 +58,7 @@ __all__ = [
     "ValidationResultList",
     "ValidationError",
     "ValidationTask",
-    "ModelValidationTask",
+    "CheckModel",
     "CheckTableExists",
     "CheckMeasurementTable",
     "CheckConditionTable",
@@ -175,7 +175,7 @@ class ValidationTask(ABC):
         return self.run(*args, **kwargs)
 
 
-class ModelValidationTask(ValidationTask):
+class CheckModel(ValidationTask):
     """A task to validate the model of a PEtab problem."""
 
     def run(self, problem: Problem) -> ValidationIssue | None:
@@ -537,7 +537,7 @@ default_validation_tasks = [
     CheckTableExists("measurement"),
     CheckTableExists("observable"),
     CheckTableExists("parameter"),
-    ModelValidationTask(),
+    CheckModel(),
     CheckMeasurementTable(),
     CheckConditionTable(),
     CheckObservableTable(),

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -158,8 +158,7 @@ def lint_problem(problem: Problem | str | Path) -> ValidationResultList:
         A list of validation results. Empty if no issues were found.
     """
 
-    if isinstance(problem, str | Path):
-        problem = Problem.from_yaml(str(problem))
+    problem = Problem.get_problem(problem)
 
     return problem.validate()
 

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -271,6 +271,27 @@ class Problem:
 
         return problem
 
+    @staticmethod
+    def get_problem(problem: str | Path | Problem):
+        """Get a PEtab problem from a file or a problem object.
+
+        Arguments:
+            problem: Path to a PEtab problem file or a PEtab problem object.
+
+        Returns:
+            A PEtab problem object.
+        """
+        if isinstance(problem, Problem):
+            return problem
+
+        if isinstance(problem, str | Path):
+            return Problem.from_yaml(problem)
+
+        raise TypeError(
+            "The argument `problem` must be a path to a PEtab problem file "
+            "or a PEtab problem object."
+        )
+
     def get_optimization_parameters(self):
         """
         Return list of optimization parameter IDs.

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -649,13 +649,18 @@ class Problem:
             )
 
         for task in self.validation_tasks:
-            cur_results = task.run(self)
-            validation_results.extend(cur_results)
+            try:
+                cur_result = task.run(self)
+            except Exception as e:
+                cur_result = ValidationResult(
+                    ValidationEventLevel.CRITICAL,
+                    f"Validation task {task} failed with exception: {e}",
+                )
 
-            if any(
-                result.level == ValidationEventLevel.CRITICAL
-                for result in cur_results
-            ):
-                break
+            if cur_result:
+                validation_results.append(cur_result)
+
+                if cur_result.level == ValidationEventLevel.CRITICAL:
+                    break
 
         return validation_results

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -25,7 +25,7 @@ from ..v1.yaml import get_path_prefix
 
 if TYPE_CHECKING:
     from ..v2.lint import (
-        ValidationResult,
+        ValidationIssue,
         ValidationResultList,
     )
 
@@ -635,13 +635,13 @@ class Problem:
 
     def validate(self) -> ValidationResultList:
         """Validate the PEtab problem."""
-        from ..v2.lint import ValidationEventLevel, ValidationResultList
+        from ..v2.lint import ValidationIssueSeverity, ValidationResultList
 
         validation_results = ValidationResultList()
         if self.extensions_config:
             validation_results.append(
-                ValidationResult(
-                    ValidationEventLevel.WARNING,
+                ValidationIssue(
+                    ValidationIssueSeverity.WARNING,
                     "Validation of PEtab extensions is not yet implemented, "
                     "but the given problem uses the following extensions: "
                     f"{'', ''.join(self.extensions_config.keys())}",
@@ -652,15 +652,15 @@ class Problem:
             try:
                 cur_result = task.run(self)
             except Exception as e:
-                cur_result = ValidationResult(
-                    ValidationEventLevel.CRITICAL,
+                cur_result = ValidationIssue(
+                    ValidationIssueSeverity.CRITICAL,
                     f"Validation task {task} failed with exception: {e}",
                 )
 
             if cur_result:
                 validation_results.append(cur_result)
 
-                if cur_result.level == ValidationEventLevel.CRITICAL:
+                if cur_result.level == ValidationIssueSeverity.CRITICAL:
                     break
 
         return validation_results

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -68,7 +68,7 @@ class Problem:
         mapping_df: pd.DataFrame = None,
         extensions_config: dict = None,
     ):
-        from ..v2.lint import ValidationTask, default_validation_taks
+        from ..v2.lint import ValidationTask, default_validation_tasks
 
         self.condition_df: pd.DataFrame | None = condition_df
         self.measurement_df: pd.DataFrame | None = measurement_df
@@ -80,7 +80,7 @@ class Problem:
         self.extensions_config = extensions_config or {}
         self.validation_tasks: list[
             ValidationTask
-        ] = default_validation_taks.copy()
+        ] = default_validation_tasks.copy()
 
     def __str__(self):
         model = f"with model ({self.model})" if self.model else "without model"

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -24,10 +24,7 @@ from ..v1.models.model import Model, model_factory
 from ..v1.yaml import get_path_prefix
 
 if TYPE_CHECKING:
-    from ..v2.lint import (
-        ValidationIssue,
-        ValidationResultList,
-    )
+    from ..v2.lint import ValidationIssue, ValidationResultList, ValidationTask
 
 
 __all__ = ["Problem"]
@@ -68,7 +65,7 @@ class Problem:
         mapping_df: pd.DataFrame = None,
         extensions_config: dict = None,
     ):
-        from ..v2.lint import ValidationTask, default_validation_tasks
+        from ..v2.lint import default_validation_tasks
 
         self.condition_df: pd.DataFrame | None = condition_df
         self.measurement_df: pd.DataFrame | None = measurement_df
@@ -633,8 +630,17 @@ class Problem:
 
         return self.parameter_df[OBJECTIVE_PRIOR_PARAMETERS].notna().sum()
 
-    def validate(self) -> ValidationResultList:
-        """Validate the PEtab problem."""
+    def validate(
+        self, validation_tasks: list[ValidationTask] = None
+    ) -> ValidationResultList:
+        """Validate the PEtab problem.
+
+        Arguments:
+            validation_tasks: List of validation tasks to run. If ``None``
+             or empty, :attr:Problem.validation_tasks` are used.
+        Returns:
+            A list of validation results.
+        """
         from ..v2.lint import ValidationIssueSeverity, ValidationResultList
 
         validation_results = ValidationResultList()
@@ -648,7 +654,7 @@ class Problem:
                 )
             )
 
-        for task in self.validation_tasks:
+        for task in validation_tasks or self.validation_tasks:
             try:
                 cur_result = task.run(self)
             except Exception as e:

--- a/petab/versions.py
+++ b/petab/versions.py
@@ -9,18 +9,19 @@ from petab.v1.yaml import load_yaml
 from petab.v2 import Problem as V2Problem
 
 __all__ = [
-    "is_v1_problem",
-    "is_v2_problem",
+    "get_major_version",
 ]
 
 
-def is_v1_problem(problem: str | dict | Path | V1Problem | V2Problem) -> bool:
-    """Check if the given problem is a PEtab v1 problem."""
+def get_major_version(
+    problem: str | dict | Path | V1Problem | V2Problem,
+) -> int:
+    """Get the major version number of the given problem."""
     if isinstance(problem, V1Problem):
-        return True
+        return 1
 
     if isinstance(problem, V2Problem):
-        return False
+        return 2
 
     if isinstance(problem, str | Path):
         yaml_config = load_yaml(problem)
@@ -31,26 +32,4 @@ def is_v1_problem(problem: str | dict | Path | V1Problem | V2Problem) -> bool:
         raise ValueError(f"Unsupported argument type: {type(problem)}")
 
     version = str(version)
-    if version.split(".")[0] == "1":
-        return True
-
-
-def is_v2_problem(problem: str | dict | Path | V1Problem | V2Problem) -> bool:
-    """Check if the given problem is a PEtab v2 problem."""
-    if isinstance(problem, V1Problem):
-        return False
-
-    if isinstance(problem, V2Problem):
-        return True
-
-    if isinstance(problem, str | Path):
-        yaml_config = load_yaml(problem)
-        version = yaml_config.get(FORMAT_VERSION)
-    elif isinstance(problem, dict):
-        version = problem.get(FORMAT_VERSION)
-    else:
-        raise ValueError(f"Unsupported argument type: {type(problem)}")
-
-    version = str(version)
-    if version.startswith("2.") or version == "2":
-        return True
+    return int(version.split(".")[0])

--- a/petab/versions.py
+++ b/petab/versions.py
@@ -1,0 +1,56 @@
+"""Handling of PEtab version numbers."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from petab.C import FORMAT_VERSION
+from petab.v1 import Problem as V1Problem
+from petab.v1.yaml import load_yaml
+from petab.v2 import Problem as V2Problem
+
+__all__ = [
+    "is_v1_problem",
+    "is_v2_problem",
+]
+
+
+def is_v1_problem(problem: str | dict | Path | V1Problem | V2Problem) -> bool:
+    """Check if the given problem is a PEtab v1 problem."""
+    if isinstance(problem, V1Problem):
+        return True
+
+    if isinstance(problem, V2Problem):
+        return False
+
+    if isinstance(problem, str | Path):
+        yaml_config = load_yaml(problem)
+        version = yaml_config.get(FORMAT_VERSION)
+    elif isinstance(problem, dict):
+        version = problem.get(FORMAT_VERSION)
+    else:
+        raise ValueError(f"Unsupported argument type: {type(problem)}")
+
+    version = str(version)
+    if version.startswith("1.") or version == "1":
+        return True
+
+
+def is_v2_problem(problem: str | dict | Path | V1Problem | V2Problem) -> bool:
+    """Check if the given problem is a PEtab v2 problem."""
+    if isinstance(problem, V1Problem):
+        return False
+
+    if isinstance(problem, V2Problem):
+        return True
+
+    if isinstance(problem, str | Path):
+        yaml_config = load_yaml(problem)
+        version = yaml_config.get(FORMAT_VERSION)
+    elif isinstance(problem, dict):
+        version = problem.get(FORMAT_VERSION)
+    else:
+        raise ValueError(f"Unsupported argument type: {type(problem)}")
+
+    version = str(version)
+    if version.startswith("2.") or version == "2":
+        return True

--- a/petab/versions.py
+++ b/petab/versions.py
@@ -31,7 +31,7 @@ def is_v1_problem(problem: str | dict | Path | V1Problem | V2Problem) -> bool:
         raise ValueError(f"Unsupported argument type: {type(problem)}")
 
     version = str(version)
-    if version.startswith("1.") or version == "1":
+    if version.split(".")[0] == "1":
         return True
 
 

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -16,6 +16,8 @@ def test_load_remote():
         and not petab_problem.measurement_df.empty
     )
 
+    petab_problem.validate()
+
     yaml_url = yaml_url.replace("2.0.0", "1.0.0")
     with pytest.raises(
         ValueError, match="Provided PEtab files are of unsupported version"

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -16,7 +16,7 @@ def test_load_remote():
         and not petab_problem.measurement_df.empty
     )
 
-    petab_problem.validate()
+    assert petab_problem.validate() == []
 
     yaml_url = yaml_url.replace("2.0.0", "1.0.0")
     with pytest.raises(


### PR DESCRIPTION
For petab.v2, refactor the current validation setup to 
* be more modular
* allow PEtab extensions to register additional validation steps in the future
* make validation messages accessible programmatically (previously, they were logged directly)

Also:
* Make `petablint` work with both v1 and v2 problems.
* Add first validation rules that are specific to v2