### PR TITLE
Add petab.v2.C

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -28,5 +28,6 @@ API Reference
    petab.v1.visualize
    petab.v1.yaml
    petab.v2
+   petab.v2.C
    petab.v2.lint
    petab.v2.problem

--- a/petab/v1/C.py
+++ b/petab/v1/C.py
@@ -115,9 +115,9 @@ PARAMETER_DF_COLS = [
     *PARAMETER_DF_OPTIONAL_COLS[1:],
 ]
 
-#: Type of prior: initialization prior
+#: Initialization-type prior
 INITIALIZATION = "initialization"
-#: Type of prior: objective prior
+#: Objective-type prior
 OBJECTIVE = "objective"
 
 
@@ -287,11 +287,11 @@ VISUALIZATION_DF_SINGLE_PLOT_LEVEL_COLS = [
     DATASET_ID,
 ]
 
-#: Plot type value in the visualization table: line plot
+#: Plot type value in the visualization table for line plot
 LINE_PLOT = "LinePlot"
-#: Plot type value in the visualization table: bar plot
+#: Plot type value in the visualization table for bar plot
 BAR_PLOT = "BarPlot"
-#: Plot type value in the visualization table: scatter plot
+#: Plot type value in the visualization table for scatter plot
 SCATTER_PLOT = "ScatterPlot"
 #: Supported plot types
 PLOT_TYPES_SIMULATION = [LINE_PLOT, BAR_PLOT, SCATTER_PLOT]
@@ -303,14 +303,15 @@ X_SCALES = [LIN, LOG, LOG10]
 Y_SCALES = [LIN, LOG, LOG10]
 
 
-#: Plot type "data" value in the visualization table: mean and standard
+#: Plot type "data" value in the visualization table for mean and standard
 #  deviation
 MEAN_AND_SD = "MeanAndSD"
-#: Plot type "data" value in the visualization table: mean and standard error
+#: Plot type "data" value in the visualization table for mean and standard
+#  error
 MEAN_AND_SEM = "MeanAndSEM"
-#: Plot type "data" value in the visualization table: replicates
+#: Plot type "data" value in the visualization table for replicates
 REPLICATE = "replicate"
-#: Plot type "data" value in the visualization table: provided noise values
+#: Plot type "data" value in the visualization table for provided noise values
 PROVIDED = "provided"
 #: Supported settings for handling replicates
 PLOT_TYPES_DATA = [MEAN_AND_SD, MEAN_AND_SEM, REPLICATE, PROVIDED]
@@ -352,11 +353,14 @@ EXTENSIONS = "extensions"
 
 # MAPPING
 
-#: Mapping table column: PEtab entity ID
+#: PEtab entity ID column in the mapping table
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 PETAB_ENTITY_ID = "petabEntityId"
-#: Mapping table column: model entity ID
+#: Model entity ID column in the mapping table
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 MODEL_ENTITY_ID = "modelEntityId"
 #: Required columns of the mapping table
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 MAPPING_DF_REQUIRED_COLS = [PETAB_ENTITY_ID, MODEL_ENTITY_ID]
 
 # MORE

--- a/petab/v1/C.py
+++ b/petab/v1/C.py
@@ -7,34 +7,34 @@ import sys
 
 # MEASUREMENTS
 
-#:
+#: Observable ID column in the observable and measurement tables
 OBSERVABLE_ID = "observableId"
 
-#:
+#: Preequilibration condition ID column in the measurement table
 PREEQUILIBRATION_CONDITION_ID = "preequilibrationConditionId"
 
-#:
+#: Simulation condition ID column in the measurement table
 SIMULATION_CONDITION_ID = "simulationConditionId"
 
-#:
+#: Measurement value column in the measurement table
 MEASUREMENT = "measurement"
 
-#:
+#: Time column in the measurement table
 TIME = "time"
 
 #: Time value that indicates steady-state measurements
 TIME_STEADY_STATE = _math.inf
 
-#:
+#: Observable parameters column in the measurement table
 OBSERVABLE_PARAMETERS = "observableParameters"
 
-#:
+#: Noise parameters column in the measurement table
 NOISE_PARAMETERS = "noiseParameters"
 
-#:
+#: Dataset ID column in the measurement table
 DATASET_ID = "datasetId"
 
-#:
+#: Replicate ID column in the measurement table
 REPLICATE_ID = "replicateId"
 
 #: Mandatory columns of measurement table
@@ -65,27 +65,27 @@ MEASUREMENT_DF_COLS = [
 
 # PARAMETERS
 
-#:
+#: Parameter ID column in the parameter table
 PARAMETER_ID = "parameterId"
-#:
+#: Parameter name column in the parameter table
 PARAMETER_NAME = "parameterName"
-#:
+#: Parameter scale column in the parameter table
 PARAMETER_SCALE = "parameterScale"
-#:
+#: Lower bound column in the parameter table
 LOWER_BOUND = "lowerBound"
-#:
+#: Upper bound column in the parameter table
 UPPER_BOUND = "upperBound"
-#:
+#: Nominal value column in the parameter table
 NOMINAL_VALUE = "nominalValue"
-#:
+#: Estimate column in the parameter table
 ESTIMATE = "estimate"
-#:
+#: Initialization prior type column in the parameter table
 INITIALIZATION_PRIOR_TYPE = "initializationPriorType"
-#:
+#: Initialization prior parameters column in the parameter table
 INITIALIZATION_PRIOR_PARAMETERS = "initializationPriorParameters"
-#:
+#: Objective prior type column in the parameter table
 OBJECTIVE_PRIOR_TYPE = "objectivePriorType"
-#:
+#: Objective prior parameters column in the parameter table
 OBJECTIVE_PRIOR_PARAMETERS = "objectivePriorParameters"
 
 #: Mandatory columns of parameter table
@@ -115,31 +115,31 @@ PARAMETER_DF_COLS = [
     *PARAMETER_DF_OPTIONAL_COLS[1:],
 ]
 
-#:
+#: Type of prior: initialization prior
 INITIALIZATION = "initialization"
-#:
+#: Type of prior: objective prior
 OBJECTIVE = "objective"
 
 
 # CONDITIONS
 
-#:
+#: Condition ID column in the condition table
 CONDITION_ID = "conditionId"
-#:
+#: Condition name column in the condition table
 CONDITION_NAME = "conditionName"
 
 
 # OBSERVABLES
 
-#:
+#: Observable name column in the observables table
 OBSERVABLE_NAME = "observableName"
-#:
+#: Observable formula column in the observables table
 OBSERVABLE_FORMULA = "observableFormula"
-#:
+#: Noise formula column in the observables table
 NOISE_FORMULA = "noiseFormula"
-#:
+#: Observable transformation column in the observables table
 OBSERVABLE_TRANSFORMATION = "observableTransformation"
-#:
+#: Noise distribution column in the observables table
 NOISE_DISTRIBUTION = "noiseDistribution"
 
 #: Mandatory columns of observables table
@@ -165,11 +165,11 @@ OBSERVABLE_DF_COLS = [
 
 # TRANSFORMATIONS
 
-#:
+#: Linear transformation
 LIN = "lin"
-#:
+#: Logarithmic transformation
 LOG = "log"
-#:
+#: Logarithmic base 10 transformation
 LOG10 = "log10"
 #: Supported observable transformations
 OBSERVABLE_TRANSFORMATIONS = [LIN, LOG, LOG10]
@@ -177,21 +177,21 @@ OBSERVABLE_TRANSFORMATIONS = [LIN, LOG, LOG10]
 
 # NOISE MODELS
 
-#:
+#: Uniform distribution
 UNIFORM = "uniform"
-#:
+#: Uniform distribution on the parameter scale
 PARAMETER_SCALE_UNIFORM = "parameterScaleUniform"
-#:
+#: Normal distribution
 NORMAL = "normal"
-#:
+#: Normal distribution on the parameter scale
 PARAMETER_SCALE_NORMAL = "parameterScaleNormal"
-#:
+#: Laplace distribution
 LAPLACE = "laplace"
-#:
+#: Laplace distribution on the parameter scale
 PARAMETER_SCALE_LAPLACE = "parameterScaleLaplace"
-#:
+#: Log-normal distribution
 LOG_NORMAL = "logNormal"
-#:
+#: Log-Laplace distribution
 LOG_LAPLACE = "logLaplace"
 
 #: Supported prior types
@@ -212,31 +212,31 @@ NOISE_MODELS = [NORMAL, LAPLACE]
 
 # VISUALIZATION
 
-#:
+#: Plot ID column in the visualization table
 PLOT_ID = "plotId"
-#:
+#: Plot name column in the visualization table
 PLOT_NAME = "plotName"
-#:
+#: Value for plot type 'simulation' in the visualization table
 PLOT_TYPE_SIMULATION = "plotTypeSimulation"
-#:
+#: Value for plot type 'data' in the visualization table
 PLOT_TYPE_DATA = "plotTypeData"
-#:
+#: X values column in the visualization table
 X_VALUES = "xValues"
-#:
+#: X offset column in the visualization table
 X_OFFSET = "xOffset"
-#:
+#: X label column in the visualization table
 X_LABEL = "xLabel"
-#:
+#: X scale column in the visualization table
 X_SCALE = "xScale"
-#:
+#: Y values column in the visualization table
 Y_VALUES = "yValues"
-#:
+#: Y offset column in the visualization table
 Y_OFFSET = "yOffset"
-#:
+#: Y label column in the visualization table
 Y_LABEL = "yLabel"
-#:
+#: Y scale column in the visualization table
 Y_SCALE = "yScale"
-#:
+#: Legend entry column in the visualization table
 LEGEND_ENTRY = "legendEntry"
 
 #: Mandatory columns of visualization table
@@ -287,11 +287,11 @@ VISUALIZATION_DF_SINGLE_PLOT_LEVEL_COLS = [
     DATASET_ID,
 ]
 
-#:
+#: Plot type value in the visualization table: line plot
 LINE_PLOT = "LinePlot"
-#:
+#: Plot type value in the visualization table: bar plot
 BAR_PLOT = "BarPlot"
-#:
+#: Plot type value in the visualization table: scatter plot
 SCATTER_PLOT = "ScatterPlot"
 #: Supported plot types
 PLOT_TYPES_SIMULATION = [LINE_PLOT, BAR_PLOT, SCATTER_PLOT]
@@ -303,65 +303,72 @@ X_SCALES = [LIN, LOG, LOG10]
 Y_SCALES = [LIN, LOG, LOG10]
 
 
-#:
+#: Plot type "data" value in the visualization table: mean and standard
+#  deviation
 MEAN_AND_SD = "MeanAndSD"
-#:
+#: Plot type "data" value in the visualization table: mean and standard error
 MEAN_AND_SEM = "MeanAndSEM"
-#:
+#: Plot type "data" value in the visualization table: replicates
 REPLICATE = "replicate"
-#:
+#: Plot type "data" value in the visualization table: provided noise values
 PROVIDED = "provided"
 #: Supported settings for handling replicates
 PLOT_TYPES_DATA = [MEAN_AND_SD, MEAN_AND_SEM, REPLICATE, PROVIDED]
 
 
 # YAML
-#:
+#: PEtab version key in the YAML file
 FORMAT_VERSION = "format_version"
-#:
+#: Parameter file key in the YAML file
 PARAMETER_FILE = "parameter_file"
-#:
+#: Problems key in the YAML file
 PROBLEMS = "problems"
-#:
+#: SBML files key in the YAML file
 SBML_FILES = "sbml_files"
-#:
+#: Model files key in the YAML file
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 MODEL_FILES = "model_files"
-#:
+#: Model location key in the YAML file
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 MODEL_LOCATION = "location"
-#:
+#: Model language key in the YAML file
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 MODEL_LANGUAGE = "language"
-#:
+#: Condition files key in the YAML file
 CONDITION_FILES = "condition_files"
-#:
+#: Measurement files key in the YAML file
 MEASUREMENT_FILES = "measurement_files"
-#:
+#: Observable files key in the YAML file
 OBSERVABLE_FILES = "observable_files"
-#:
+#: Visualization files key in the YAML file
 VISUALIZATION_FILES = "visualization_files"
-#:
+#: Mapping files key in the YAML file
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 MAPPING_FILES = "mapping_files"
-#:
+#: Extensions key in the YAML file
+#  (PEtab v2.0 -- DEPRECATED: use value from petab.v2.C)
 EXTENSIONS = "extensions"
 
 
 # MAPPING
-#:
+
+#: Mapping table column: PEtab entity ID
 PETAB_ENTITY_ID = "petabEntityId"
-#:
+#: Mapping table column: model entity ID
 MODEL_ENTITY_ID = "modelEntityId"
-#:
+#: Required columns of the mapping table
 MAPPING_DF_REQUIRED_COLS = [PETAB_ENTITY_ID, MODEL_ENTITY_ID]
 
 # MORE
 
-#:
+#: Simulated value column in the simulation table
 SIMULATION = "simulation"
-#:
+#: Residual value column in the residuals table
 RESIDUAL = "residual"
-#:
+#: ???
 NOISE_VALUE = "noiseValue"
 
-# separator for multiple parameter values (bounds, observableParameters, ...)
+#: separator for multiple parameter values (bounds, observableParameters, ...)
 PARAMETER_SEPARATOR = ";"
 
 

--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -2,8 +2,368 @@
 """
 This file contains constant definitions.
 """
+import math as _math
+import sys
 
-from petab.v1.C import *
+# MEASUREMENTS
+
+#: Observable ID column in the observable and measurement tables
+OBSERVABLE_ID = "observableId"
+
+#: Preequilibration condition ID column in the measurement table
+PREEQUILIBRATION_CONDITION_ID = "preequilibrationConditionId"
+
+#: Simulation condition ID column in the measurement table
+SIMULATION_CONDITION_ID = "simulationConditionId"
+
+#: Measurement value column in the measurement table
+MEASUREMENT = "measurement"
+
+#: Time column in the measurement table
+TIME = "time"
+
+#: Time value that indicates steady-state measurements
+TIME_STEADY_STATE = _math.inf
+
+#: Observable parameters column in the measurement table
+OBSERVABLE_PARAMETERS = "observableParameters"
+
+#: Noise parameters column in the measurement table
+NOISE_PARAMETERS = "noiseParameters"
+
+#: Dataset ID column in the measurement table
+DATASET_ID = "datasetId"
+
+#: Replicate ID column in the measurement table
+REPLICATE_ID = "replicateId"
+
+#: Mandatory columns of measurement table
+MEASUREMENT_DF_REQUIRED_COLS = [
+    OBSERVABLE_ID,
+    SIMULATION_CONDITION_ID,
+    MEASUREMENT,
+    TIME,
+]
+
+#: Optional columns of measurement table
+MEASUREMENT_DF_OPTIONAL_COLS = [
+    PREEQUILIBRATION_CONDITION_ID,
+    OBSERVABLE_PARAMETERS,
+    NOISE_PARAMETERS,
+    DATASET_ID,
+    REPLICATE_ID,
+]
+
+#: Measurement table columns
+MEASUREMENT_DF_COLS = [
+    MEASUREMENT_DF_REQUIRED_COLS[0],
+    MEASUREMENT_DF_OPTIONAL_COLS[0],
+    *MEASUREMENT_DF_REQUIRED_COLS[1:],
+    *MEASUREMENT_DF_OPTIONAL_COLS[1:],
+]
+
+
+# PARAMETERS
+
+#: Parameter ID column in the parameter table
+PARAMETER_ID = "parameterId"
+#: Parameter name column in the parameter table
+PARAMETER_NAME = "parameterName"
+#: Parameter scale column in the parameter table
+PARAMETER_SCALE = "parameterScale"
+#: Lower bound column in the parameter table
+LOWER_BOUND = "lowerBound"
+#: Upper bound column in the parameter table
+UPPER_BOUND = "upperBound"
+#: Nominal value column in the parameter table
+NOMINAL_VALUE = "nominalValue"
+#: Estimate column in the parameter table
+ESTIMATE = "estimate"
+#: Initialization prior type column in the parameter table
+INITIALIZATION_PRIOR_TYPE = "initializationPriorType"
+#: Initialization prior parameters column in the parameter table
+INITIALIZATION_PRIOR_PARAMETERS = "initializationPriorParameters"
+#: Objective prior type column in the parameter table
+OBJECTIVE_PRIOR_TYPE = "objectivePriorType"
+#: Objective prior parameters column in the parameter table
+OBJECTIVE_PRIOR_PARAMETERS = "objectivePriorParameters"
+
+#: Mandatory columns of parameter table
+PARAMETER_DF_REQUIRED_COLS = [
+    PARAMETER_ID,
+    PARAMETER_SCALE,
+    LOWER_BOUND,
+    UPPER_BOUND,
+    ESTIMATE,
+]
+
+#: Optional columns of parameter table
+PARAMETER_DF_OPTIONAL_COLS = [
+    PARAMETER_NAME,
+    NOMINAL_VALUE,
+    INITIALIZATION_PRIOR_TYPE,
+    INITIALIZATION_PRIOR_PARAMETERS,
+    OBJECTIVE_PRIOR_TYPE,
+    OBJECTIVE_PRIOR_PARAMETERS,
+]
+
+#: Parameter table columns
+PARAMETER_DF_COLS = [
+    PARAMETER_DF_REQUIRED_COLS[0],
+    PARAMETER_DF_OPTIONAL_COLS[0],
+    *PARAMETER_DF_REQUIRED_COLS[1:],
+    *PARAMETER_DF_OPTIONAL_COLS[1:],
+]
+
+#: Type of prior: initialization prior
+INITIALIZATION = "initialization"
+#: Type of prior: objective prior
+OBJECTIVE = "objective"
+
+
+# CONDITIONS
+
+#: Condition ID column in the condition table
+CONDITION_ID = "conditionId"
+#: Condition name column in the condition table
+CONDITION_NAME = "conditionName"
+
+
+# OBSERVABLES
+
+#: Observable name column in the observables table
+OBSERVABLE_NAME = "observableName"
+#: Observable formula column in the observables table
+OBSERVABLE_FORMULA = "observableFormula"
+#: Noise formula column in the observables table
+NOISE_FORMULA = "noiseFormula"
+#: Observable transformation column in the observables table
+OBSERVABLE_TRANSFORMATION = "observableTransformation"
+#: Noise distribution column in the observables table
+NOISE_DISTRIBUTION = "noiseDistribution"
+
+#: Mandatory columns of observables table
+OBSERVABLE_DF_REQUIRED_COLS = [
+    OBSERVABLE_ID,
+    OBSERVABLE_FORMULA,
+    NOISE_FORMULA,
+]
+
+#: Optional columns of observables table
+OBSERVABLE_DF_OPTIONAL_COLS = [
+    OBSERVABLE_NAME,
+    OBSERVABLE_TRANSFORMATION,
+    NOISE_DISTRIBUTION,
+]
+
+#: Observables table columns
+OBSERVABLE_DF_COLS = [
+    *OBSERVABLE_DF_REQUIRED_COLS,
+    *OBSERVABLE_DF_OPTIONAL_COLS,
+]
+
+
+# TRANSFORMATIONS
+
+#: Linear transformation
+LIN = "lin"
+#: Logarithmic transformation
+LOG = "log"
+#: Logarithmic base 10 transformation
+LOG10 = "log10"
+#: Supported observable transformations
+OBSERVABLE_TRANSFORMATIONS = [LIN, LOG, LOG10]
+
+
+# NOISE MODELS
+
+#: Uniform distribution
+UNIFORM = "uniform"
+#: Uniform distribution on the parameter scale
+PARAMETER_SCALE_UNIFORM = "parameterScaleUniform"
+#: Normal distribution
+NORMAL = "normal"
+#: Normal distribution on the parameter scale
+PARAMETER_SCALE_NORMAL = "parameterScaleNormal"
+#: Laplace distribution
+LAPLACE = "laplace"
+#: Laplace distribution on the parameter scale
+PARAMETER_SCALE_LAPLACE = "parameterScaleLaplace"
+#: Log-normal distribution
+LOG_NORMAL = "logNormal"
+#: Log-Laplace distribution
+LOG_LAPLACE = "logLaplace"
+
+#: Supported prior types
+PRIOR_TYPES = [
+    UNIFORM,
+    NORMAL,
+    LAPLACE,
+    LOG_NORMAL,
+    LOG_LAPLACE,
+    PARAMETER_SCALE_UNIFORM,
+    PARAMETER_SCALE_NORMAL,
+    PARAMETER_SCALE_LAPLACE,
+]
+
+#: Supported noise distributions
+NOISE_MODELS = [NORMAL, LAPLACE]
+
+
+# VISUALIZATION
+
+#: Plot ID column in the visualization table
+PLOT_ID = "plotId"
+#: Plot name column in the visualization table
+PLOT_NAME = "plotName"
+#: Value for plot type 'simulation' in the visualization table
+PLOT_TYPE_SIMULATION = "plotTypeSimulation"
+#: Value for plot type 'data' in the visualization table
+PLOT_TYPE_DATA = "plotTypeData"
+#: X values column in the visualization table
+X_VALUES = "xValues"
+#: X offset column in the visualization table
+X_OFFSET = "xOffset"
+#: X label column in the visualization table
+X_LABEL = "xLabel"
+#: X scale column in the visualization table
+X_SCALE = "xScale"
+#: Y values column in the visualization table
+Y_VALUES = "yValues"
+#: Y offset column in the visualization table
+Y_OFFSET = "yOffset"
+#: Y label column in the visualization table
+Y_LABEL = "yLabel"
+#: Y scale column in the visualization table
+Y_SCALE = "yScale"
+#: Legend entry column in the visualization table
+LEGEND_ENTRY = "legendEntry"
+
+#: Mandatory columns of visualization table
+VISUALIZATION_DF_REQUIRED_COLS = [PLOT_ID]
+
+#: Optional columns of visualization table
+VISUALIZATION_DF_OPTIONAL_COLS = [
+    PLOT_NAME,
+    PLOT_TYPE_SIMULATION,
+    PLOT_TYPE_DATA,
+    X_VALUES,
+    X_OFFSET,
+    X_LABEL,
+    X_SCALE,
+    Y_VALUES,
+    Y_OFFSET,
+    Y_LABEL,
+    Y_SCALE,
+    LEGEND_ENTRY,
+    DATASET_ID,
+]
+
+#: Visualization table columns
+VISUALIZATION_DF_COLS = [
+    *VISUALIZATION_DF_REQUIRED_COLS,
+    *VISUALIZATION_DF_OPTIONAL_COLS,
+]
+
+#: Visualization table columns that contain subplot specifications
+VISUALIZATION_DF_SUBPLOT_LEVEL_COLS = [
+    PLOT_ID,
+    PLOT_NAME,
+    PLOT_TYPE_SIMULATION,
+    PLOT_TYPE_DATA,
+    X_LABEL,
+    X_SCALE,
+    Y_LABEL,
+    Y_SCALE,
+]
+
+#: Visualization table columns that contain single plot specifications
+VISUALIZATION_DF_SINGLE_PLOT_LEVEL_COLS = [
+    X_VALUES,
+    X_OFFSET,
+    Y_VALUES,
+    Y_OFFSET,
+    LEGEND_ENTRY,
+    DATASET_ID,
+]
+
+#: Plot type value in the visualization table: line plot
+LINE_PLOT = "LinePlot"
+#: Plot type value in the visualization table: bar plot
+BAR_PLOT = "BarPlot"
+#: Plot type value in the visualization table: scatter plot
+SCATTER_PLOT = "ScatterPlot"
+#: Supported plot types
+PLOT_TYPES_SIMULATION = [LINE_PLOT, BAR_PLOT, SCATTER_PLOT]
+
+#: Supported xScales
+X_SCALES = [LIN, LOG, LOG10]
+
+#: Supported yScales
+Y_SCALES = [LIN, LOG, LOG10]
+
+
+#: Plot type "data" value in the visualization table: mean and standard
+#  deviation
+MEAN_AND_SD = "MeanAndSD"
+#: Plot type "data" value in the visualization table: mean and standard error
+MEAN_AND_SEM = "MeanAndSEM"
+#: Plot type "data" value in the visualization table: replicates
+REPLICATE = "replicate"
+#: Plot type "data" value in the visualization table: provided noise values
+PROVIDED = "provided"
+#: Supported settings for handling replicates
+PLOT_TYPES_DATA = [MEAN_AND_SD, MEAN_AND_SEM, REPLICATE, PROVIDED]
+
+
+# YAML
+#: PEtab version key in the YAML file
+FORMAT_VERSION = "format_version"
+#: Parameter file key in the YAML file
+PARAMETER_FILE = "parameter_file"
+#: Problems key in the YAML file
+PROBLEMS = "problems"
+#: Model files key in the YAML file
+MODEL_FILES = "model_files"
+#: Model location key in the YAML file
+MODEL_LOCATION = "location"
+#: Model language key in the YAML file
+MODEL_LANGUAGE = "language"
+#: Condition files key in the YAML file
+CONDITION_FILES = "condition_files"
+#: Measurement files key in the YAML file
+MEASUREMENT_FILES = "measurement_files"
+#: Observable files key in the YAML file
+OBSERVABLE_FILES = "observable_files"
+#: Visualization files key in the YAML file
+VISUALIZATION_FILES = "visualization_files"
+#: Mapping files key in the YAML file
+MAPPING_FILES = "mapping_files"
+#: Extensions key in the YAML file
+EXTENSIONS = "extensions"
+
+
+# MAPPING
+
+#: Mapping table column: PEtab entity ID
+PETAB_ENTITY_ID = "petabEntityId"
+#: Mapping table column: model entity ID
+MODEL_ENTITY_ID = "modelEntityId"
+#: Required columns of the mapping table
+MAPPING_DF_REQUIRED_COLS = [PETAB_ENTITY_ID, MODEL_ENTITY_ID]
+
+# MORE
+
+#: Simulated value column in the simulation table
+SIMULATION = "simulation"
+#: Residual value column in the residuals table
+RESIDUAL = "residual"
+#: ???
+NOISE_VALUE = "noiseValue"
+
+#: separator for multiple parameter values (bounds, observableParameters, ...)
+PARAMETER_SEPARATOR = ";"
+
 
 __all__ = [
     x

--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -115,9 +115,9 @@ PARAMETER_DF_COLS = [
     *PARAMETER_DF_OPTIONAL_COLS[1:],
 ]
 
-#: Type of prior: initialization prior
+#: Initialization-type prior
 INITIALIZATION = "initialization"
-#: Type of prior: objective prior
+#: Objective-type prior
 OBJECTIVE = "objective"
 
 
@@ -287,11 +287,11 @@ VISUALIZATION_DF_SINGLE_PLOT_LEVEL_COLS = [
     DATASET_ID,
 ]
 
-#: Plot type value in the visualization table: line plot
+#: Plot type value in the visualization table for line plot
 LINE_PLOT = "LinePlot"
-#: Plot type value in the visualization table: bar plot
+#: Plot type value in the visualization table for bar plot
 BAR_PLOT = "BarPlot"
-#: Plot type value in the visualization table: scatter plot
+#: Plot type value in the visualization table for scatter plot
 SCATTER_PLOT = "ScatterPlot"
 #: Supported plot types
 PLOT_TYPES_SIMULATION = [LINE_PLOT, BAR_PLOT, SCATTER_PLOT]
@@ -303,14 +303,15 @@ X_SCALES = [LIN, LOG, LOG10]
 Y_SCALES = [LIN, LOG, LOG10]
 
 
-#: Plot type "data" value in the visualization table: mean and standard
+#: Plot type "data" value in the visualization table for mean and standard
 #  deviation
 MEAN_AND_SD = "MeanAndSD"
-#: Plot type "data" value in the visualization table: mean and standard error
+#: Plot type "data" value in the visualization table for mean and standard
+#  error
 MEAN_AND_SEM = "MeanAndSEM"
-#: Plot type "data" value in the visualization table: replicates
+#: Plot type "data" value in the visualization table for replicates
 REPLICATE = "replicate"
-#: Plot type "data" value in the visualization table: provided noise values
+#: Plot type "data" value in the visualization table for provided noise values
 PROVIDED = "provided"
 #: Supported settings for handling replicates
 PLOT_TYPES_DATA = [MEAN_AND_SD, MEAN_AND_SEM, REPLICATE, PROVIDED]
@@ -345,9 +346,9 @@ EXTENSIONS = "extensions"
 
 # MAPPING
 
-#: Mapping table column: PEtab entity ID
+#: PEtab entity ID column in the mapping table
 PETAB_ENTITY_ID = "petabEntityId"
-#: Mapping table column: model entity ID
+#: Model entity ID column in the mapping table
 MODEL_ENTITY_ID = "modelEntityId"
 #: Required columns of the mapping table
 MAPPING_DF_REQUIRED_COLS = [PETAB_ENTITY_ID, MODEL_ENTITY_ID]

--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -1,0 +1,12 @@
+# pylint: disable:invalid-name
+"""
+This file contains constant definitions.
+"""
+
+from petab.v1.C import *
+
+__all__ = [
+    x
+    for x in dir(sys.modules[__name__])
+    if not x.startswith("_") and x not in {"sys", "math"}
+]


### PR DESCRIPTION
For now, mostly a copy of v1. The be updated as petab v2 development progresses.

Also adds some missing documentation.

Use of PEtab v2-related constants from `petab.v1.C` is deprecated.


:eyes: https://petab--299.org.readthedocs.build/projects/libpetab-python/en/299/build/_autosummary/petab.v2.C.html