### PR TITLE
doc: add petab.v1.priors

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -20,6 +20,7 @@ API Reference
    petab.v1.observables
    petab.v1.parameter_mapping
    petab.v1.parameters
+   petab.v1.priors
    petab.v1.problem
    petab.v1.sampling
    petab.v1.sbml

--- a/petab/v1/priors.py
+++ b/petab/v1/priors.py
@@ -32,6 +32,8 @@ from . import (
     Problem,
 )
 
+__all__ = ["priors_to_measurements"]
+
 
 def priors_to_measurements(problem: Problem):
     """Convert priors to measurements.


### PR DESCRIPTION
petab.v1.priors was not included in the documentation.