### PR TITLE
Store problem configuration in Problem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pyyaml",
     "jsonschema",
     "antlr4-python3-runtime==4.13.1",
+    "pydantic>=2.10",
 ]
 license = {text = "MIT License"}
 authors = [


### PR DESCRIPTION
Introduces `Problem.config` which contains the info from the PEtab yaml file.

Sometimes it is convenient to have the original filenames around.

Pydantic gives more helpful error messages than `jsonschema` in case of incorrect inputs. Later on, this could replace  `jsonschema` completely.

If accepted, I will add the same for `petab.v2.Problem`.

Related to #324.