### PR TITLE
Refactor priors

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -10,6 +10,7 @@ The following examples should help to get a better idea of how to use the PEtab 
 
    example/example_petablint.ipynb
    example/example_visualization.ipynb
+   example/distributions.ipynb
 
 Examples of systems biology parameter estimation problems specified in PEtab
 can be found in the `systems biology benchmark model collection <https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab>`_.

--- a/doc/example/distributions.ipynb
+++ b/doc/example/distributions.ipynb
@@ -177,18 +177,9 @@
    "source": [
     "plot(Prior(NORMAL, (10, 1), bounds=(6, 14), transformation=\"log10\"))\n",
     "plot(Prior(PARAMETER_SCALE_NORMAL, (10, 1), bounds=(10**6, 10**14), transformation=\"log10\"))\n",
-    "plot(Prior(LAPLACE, (10, 2), bounds=(6, 14)))\n",
-    "\n"
+    "plot(Prior(LAPLACE, (10, 2), bounds=(6, 14)))"
    ],
    "id": "581e1ac431860419",
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "source": "",
-   "id": "633733651bbc3ef0",
    "outputs": [],
    "execution_count": null
   }

--- a/doc/example/distributions.ipynb
+++ b/doc/example/distributions.ipynb
@@ -32,34 +32,34 @@
     "import seaborn as sns\n",
     "\n",
     "from petab.v1.C import *\n",
-    "from petab.v1.distributions import *\n",
+    "from petab.v1.priors import Prior\n",
     "\n",
     "sns.set_style(None)\n",
     "\n",
     "\n",
-    "def plot(distr: Distribution, ax=None):\n",
+    "def plot(prior: Prior, ax=None):\n",
     "    \"\"\"Visualize a distribution.\"\"\"\n",
     "    if ax is None:\n",
     "        fig, ax = plt.subplots()\n",
     "\n",
-    "    sample = distr.sample(10000)\n",
+    "    sample = prior.sample(10000)\n",
     "\n",
     "    # pdf\n",
-    "    xmin = min(sample.min(), distr.lb_scaled if distr.bounds is not None else sample.min())\n",
-    "    xmax = max(sample.max(), distr.ub_scaled if distr.bounds is not None else sample.max())\n",
+    "    xmin = min(sample.min(), prior.lb_scaled if prior.bounds is not None else sample.min())\n",
+    "    xmax = max(sample.max(), prior.ub_scaled if prior.bounds is not None else sample.max())\n",
     "    x = np.linspace(xmin, xmax, 500)\n",
-    "    y = distr.pdf(x)\n",
+    "    y = prior.pdf(x)\n",
     "    ax.plot(x, y, color='red', label='pdf')\n",
     "\n",
     "    sns.histplot(sample, stat='density', ax=ax, label=\"sample\")\n",
     "\n",
     "    # bounds\n",
-    "    if distr.bounds is not None:\n",
-    "        for bound in (distr.lb_scaled, distr.ub_scaled):\n",
+    "    if prior.bounds is not None:\n",
+    "        for bound in (prior.lb_scaled, prior.ub_scaled):\n",
     "            if bound is not None and np.isfinite(bound):\n",
     "                ax.axvline(bound, color='black', linestyle='--', label='bound')\n",
     "\n",
-    "    ax.set_title(str(distr))\n",
+    "    ax.set_title(str(prior))\n",
     "    ax.set_xlabel('Parameter value on the parameter scale')\n",
     "    ax.grid(False)\n",
     "    handles, labels = ax.get_legend_handles_labels()\n",
@@ -81,11 +81,11 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Uniform(0, 1))\n",
-    "plot(Normal(0, 1))\n",
-    "plot(Laplace(0, 1))\n",
-    "plot(LogNormal(0, 1))\n",
-    "plot(LogLaplace(1, 0.5))"
+    "plot(Prior(UNIFORM, (0, 1)))\n",
+    "plot(Prior(NORMAL, (0, 1)))\n",
+    "plot(Prior(LAPLACE, (0, 1)))\n",
+    "plot(Prior(LOG_NORMAL, (0, 1)))\n",
+    "plot(Prior(LOG_LAPLACE, (1, 0.5)))"
    ],
    "id": "4f09e50a3db06d9f",
    "outputs": [],
@@ -101,10 +101,11 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Normal(10, 2, transformation=LIN))\n",
-    "plot(Normal(10, 2, transformation=LOG))\n",
+    "plot(Prior(NORMAL, (10, 2), transformation=LIN))\n",
+    "plot(Prior(NORMAL, (10, 2), transformation=LOG))\n",
+    "\n",
     "# Note that the log-normal distribution is different from a log-transformed normal distribution:\n",
-    "plot(LogNormal(10, 2, transformation=LIN))"
+    "plot(Prior(LOG_NORMAL, (10, 2), transformation=LIN))"
    ],
    "id": "f6192c226f179ef9",
    "outputs": [],
@@ -120,8 +121,8 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(LogNormal(10, 2, transformation=LOG))\n",
-    "plot(ParameterScaleNormal(10, 2))"
+    "plot(Prior(LOG_NORMAL, (10, 2), transformation=LOG))\n",
+    "plot(Prior(PARAMETER_SCALE_NORMAL, (10, 2)))"
    ],
    "id": "34c95268e8921070",
    "outputs": [],
@@ -137,11 +138,11 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Uniform(0, 1, transformation=LOG10))\n",
-    "plot(ParameterScaleUniform(0, 1, transformation=LOG10))\n",
+    "plot(Prior(UNIFORM, (0.01, 2), transformation=LOG10))\n",
+    "plot(Prior(PARAMETER_SCALE_UNIFORM, (0.01, 2), transformation=LOG10))\n",
     "\n",
-    "plot(Uniform(0, 1, transformation=LIN))\n",
-    "plot(ParameterScaleUniform(0, 1, transformation=LIN))\n"
+    "plot(Prior(UNIFORM, (0.01, 2), transformation=LIN))\n",
+    "plot(Prior(PARAMETER_SCALE_UNIFORM, (0.01, 2), transformation=LIN))\n"
    ],
    "id": "5ca940bc24312fc6",
    "outputs": [],
@@ -157,8 +158,8 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Normal(0, 1, bounds=(-4, 4)))  # negligible clipping-bias at 4 sigma\n",
-    "plot(Uniform(0, 1, bounds=(0.1, 0.9)))  # significant clipping-bias"
+    "plot(Prior(NORMAL, (0, 1), bounds=(-4, 4)))  # negligible clipping-bias at 4 sigma\n",
+    "plot(Prior(UNIFORM, (0, 1), bounds=(0.1, 0.9)))  # significant clipping-bias"
    ],
    "id": "4ac42b1eed759bdd",
    "outputs": [],
@@ -174,8 +175,10 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Normal(10, 1, bounds=(6, 14), transformation=\"log10\"))\n",
-    "plot(ParameterScaleNormal(10, 1, bounds=(10**6, 10**14), transformation=\"log10\"))\n"
+    "plot(Prior(NORMAL, (10, 1), bounds=(6, 14), transformation=\"log10\"))\n",
+    "plot(Prior(PARAMETER_SCALE_NORMAL, (10, 1), bounds=(10**6, 10**14), transformation=\"log10\"))\n",
+    "plot(Prior(LAPLACE, (10, 2), bounds=(6, 14)))\n",
+    "\n"
    ],
    "id": "581e1ac431860419",
    "outputs": [],
@@ -185,7 +188,7 @@
    "metadata": {},
    "cell_type": "code",
    "source": "",
-   "id": "802a64be56a6c94f",
+   "id": "633733651bbc3ef0",
    "outputs": [],
    "execution_count": null
   }

--- a/doc/example/distributions.ipynb
+++ b/doc/example/distributions.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Prior distributions in PEtab\n",
+    "\n",
+    "This notebook gives a brief overview of the prior distributions in PEtab and how they are represented in the PEtab library.\n",
+    "\n",
+    "Prior distributions are used to specify the prior knowledge about the parameters.\n",
+    "Parameter priors are specified in the parameter table. A prior is defined by its type and its parameters.\n",
+    "Each prior type has a specific set of parameters. For example, the normal distribution has two parameters: the mean and the standard deviation.\n",
+    "\n",
+    "There are two types of priors in PEtab - objective priors and initialization priors:\n",
+    "\n",
+    "* *Objective priors* are used to specify the prior knowledge about the parameters that are to be estimated. They will enter the objective function of the optimization problem. They are specified in the `objectivePriorType` and `objectivePriorParameters` columns of the parameter table.\n",
+    "* *Initialization priors* can be used as a hint for the optimization algorithm. They will not enter the objective function. They are specified in the `initializationPriorType` and `initializationPriorParameters` columns of the parameter table.\n",
+    "\n",
+    "\n"
+   ],
+   "id": "372289411a2aa7b3"
+  },
+  {
+   "metadata": {
+    "collapsed": true
+   },
+   "cell_type": "code",
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from petab.v1.C import *\n",
+    "from petab.v1.distributions import *\n",
+    "\n",
+    "sns.set_style(None)\n",
+    "\n",
+    "\n",
+    "def plot(distr: Distribution, ax=None):\n",
+    "    \"\"\"Visualize a distribution.\"\"\"\n",
+    "    if ax is None:\n",
+    "        fig, ax = plt.subplots()\n",
+    "\n",
+    "    sample = distr.sample(10000)\n",
+    "\n",
+    "    # pdf\n",
+    "    xmin = min(sample.min(), distr.lb_scaled if distr.bounds is not None else sample.min())\n",
+    "    xmax = max(sample.max(), distr.ub_scaled if distr.bounds is not None else sample.max())\n",
+    "    x = np.linspace(xmin, xmax, 500)\n",
+    "    y = distr.pdf(x)\n",
+    "    ax.plot(x, y, color='red', label='pdf')\n",
+    "\n",
+    "    sns.histplot(sample, stat='density', ax=ax, label=\"sample\")\n",
+    "\n",
+    "    # bounds\n",
+    "    if distr.bounds is not None:\n",
+    "        for bound in (distr.lb_scaled, distr.ub_scaled):\n",
+    "            if bound is not None and np.isfinite(bound):\n",
+    "                ax.axvline(bound, color='black', linestyle='--', label='bound')\n",
+    "\n",
+    "    ax.set_title(str(distr))\n",
+    "    ax.set_xlabel('Parameter value on the parameter scale')\n",
+    "    ax.grid(False)\n",
+    "    handles, labels = ax.get_legend_handles_labels()\n",
+    "    unique_labels = dict(zip(labels, handles))\n",
+    "    ax.legend(unique_labels.values(), unique_labels.keys())\n",
+    "    plt.show()"
+   ],
+   "id": "initial_id",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "The basic distributions are the uniform, normal, Laplace, log-normal, and log-laplace distributions:\n",
+   "id": "db36a4a93622ccb8"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Uniform(0, 1))\n",
+    "plot(Normal(0, 1))\n",
+    "plot(Laplace(0, 1))\n",
+    "plot(LogNormal(0, 1))\n",
+    "plot(LogLaplace(1, 0.5))"
+   ],
+   "id": "4f09e50a3db06d9f",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "If a parameter scale is specified (`parameterScale=lin|log|log10` not a `parameterScale*`-type distribution), the sample is transformed accordingly (but not the distribution parameters):\n",
+   "id": "dab4b2d1e0f312d8"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Normal(10, 2, transformation=LIN))\n",
+    "plot(Normal(10, 2, transformation=LOG))\n",
+    "# Note that the log-normal distribution is different from a log-transformed normal distribution:\n",
+    "plot(LogNormal(10, 2, transformation=LIN))"
+   ],
+   "id": "f6192c226f179ef9",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "On the log-transformed parameter scale, `Log*` and `parameterScale*` distributions are equivalent:",
+   "id": "4281ed48859e6431"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(LogNormal(10, 2, transformation=LOG))\n",
+    "plot(ParameterScaleNormal(10, 2))"
+   ],
+   "id": "34c95268e8921070",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Prior distributions can also be defined on the parameter scale by using the types `parameterScaleUniform`, `parameterScaleNormal` or `parameterScaleLaplace`. In these cases, 1) the distribution parameter are interpreted on the transformed parameter scale, and 2) a sample from the given distribution is used directly, without applying any transformation according to `parameterScale` (this implies, that for `parameterScale=lin`, there is no difference between `parameterScaleUniform` and `uniform`):",
+   "id": "263c9fd31156a4d5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Uniform(0, 1, transformation=LOG10))\n",
+    "plot(ParameterScaleUniform(0, 1, transformation=LOG10))\n",
+    "\n",
+    "plot(Uniform(0, 1, transformation=LIN))\n",
+    "plot(ParameterScaleUniform(0, 1, transformation=LIN))\n"
+   ],
+   "id": "5ca940bc24312fc6",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "To prevent the sampled parameters from exceeding the bounds, the sampled parameters are clipped to the bounds. The bounds are defined in the parameter table. Note that the current implementation does not support sampling from a truncated distribution. Instead, the samples are clipped to the bounds. This may introduce unwanted bias, and thus, should only be used with caution (i.e., the bounds should be chosen wide enough):",
+   "id": "b1a8b17d765db826"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Normal(0, 1, bounds=(-4, 4)))  # negligible clipping-bias at 4 sigma\n",
+    "plot(Uniform(0, 1, bounds=(0.1, 0.9)))  # significant clipping-bias"
+   ],
+   "id": "4ac42b1eed759bdd",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Further distribution examples:",
+   "id": "45ffce1341483f24"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Normal(10, 1, bounds=(6, 14), transformation=\"log10\"))\n",
+    "plot(ParameterScaleNormal(10, 1, bounds=(10**6, 10**14), transformation=\"log10\"))\n"
+   ],
+   "id": "581e1ac431860419",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "",
+   "id": "802a64be56a6c94f",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -14,6 +14,7 @@ API Reference
    petab.v1.composite_problem
    petab.v1.conditions
    petab.v1.core
+   petab.v1.distributions
    petab.v1.lint
    petab.v1.measurements
    petab.v1.models

--- a/petab/v1/C.py
+++ b/petab/v1/C.py
@@ -173,7 +173,8 @@ LOG = "log"
 LOG10 = "log10"
 #: Supported observable transformations
 OBSERVABLE_TRANSFORMATIONS = [LIN, LOG, LOG10]
-
+#: Supported parameter transformations
+PARAMETER_SCALES = [LIN, LOG, LOG10]
 
 # NOISE MODELS
 

--- a/petab/v1/distributions.py
+++ b/petab/v1/distributions.py
@@ -1,0 +1,436 @@
+"""Probability distributions used by PEtab."""
+from __future__ import annotations
+
+import abc
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+from scipy.stats import laplace, lognorm, norm, uniform
+
+from . import C
+from .parameters import scale, unscale
+
+__all__ = [
+    "Distribution",
+    "Normal",
+    "LogNormal",
+    "Uniform",
+    "Laplace",
+    "LogLaplace",
+    "ParameterScaleNormal",
+    "ParameterScaleUniform",
+    "ParameterScaleLaplace",
+]
+
+
+class Distribution(abc.ABC):
+    """A univariate probability distribution.
+
+    :param type_: The type of the distribution.
+    :param transformation: The transformation to be applied to the sample.
+        Ignored if `parameter_scale` is `True`.
+    :param parameters: The parameters of the distribution (unaffected by
+        `parameter_scale` and `transformation`).
+    :param bounds: The untransformed bounds of the sample (lower, upper).
+    :param parameter_scale: Whether the parameters are already on the correct
+        scale. If `False`, the parameters are transformed to the correct scale.
+        If `True`, the parameters are assumed to be on the correct scale and
+        no transformation is applied.
+    :param transformation: The transformation of the distribution.
+
+    """
+
+    #: Mapping from distribution type to distribution class for factory method.
+    _type_to_cls: dict[str, type[Distribution]] = {}
+
+    def __init__(
+        self,
+        type_: str,
+        transformation: str,
+        parameters: tuple,
+        bounds: tuple = None,
+        parameter_scale: bool = False,
+    ):
+        if type_ not in self._type_to_cls:
+            raise ValueError(f"Unknown distribution type: {type_}")
+
+        if len(parameters) != 2:
+            raise ValueError(
+                f"Expected two parameters, got {len(parameters)}: {parameters}"
+            )
+
+        if bounds is not None and len(bounds) != 2:
+            raise ValueError(
+                f"Expected two bounds, got {len(bounds)}: {bounds}"
+            )
+
+        self.type = type_
+        self.parameters = parameters
+        self.bounds = bounds
+        self.transformation = transformation
+        self.parameter_scale = parameter_scale
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"{self.parameters[0]!r}, {self.parameters[1]!r},"
+            f" bounds={self.bounds!r}, transformation={self.transformation!r}"
+            ")"
+        )
+
+    @abc.abstractmethod
+    def sample(self, shape=None) -> np.ndarray:
+        """Sample from the distribution.
+
+        :param shape: The shape of the sample.
+        :return: A sample from the distribution.
+        """
+        ...
+
+    def _scale_sample(self, sample):
+        """Scale the sample to the parameter space"""
+        if self.parameter_scale:
+            return sample
+
+        return scale(sample, self.transformation)
+
+    def _clip_to_bounds(self, x):
+        """Clip `x` values to bounds.
+
+        :param x: The values to clip. Assumed to be on the parameter scale.
+        """
+        # TODO: replace this by proper truncation
+        if self.bounds is None:
+            return x
+
+        return np.maximum(
+            np.minimum(self.ub_scaled, x),
+            self.lb_scaled,
+        )
+
+    @property
+    def lb_scaled(self):
+        """The lower bound on the parameter scale."""
+        return scale(self.bounds[0], self.transformation)
+
+    @property
+    def ub_scaled(self):
+        """The upper bound on the parameter scale."""
+        return scale(self.bounds[1], self.transformation)
+
+    @abc.abstractmethod
+    def _pdf(self, x):
+        """Probability density function at x.
+
+        :param x: The value at which to evaluate the PDF.
+            ``x`` is assumed to be on the linear scale.
+        :return: The value of the PDF at ``x``.
+        """
+        ...
+
+    def pdf(self, x):
+        """Probability density function at x.
+
+        :param x: The value at which to evaluate the PDF.
+            ``x`` is assumed to be on the parameter scale.
+        :return: The value of the PDF at ``x``. Note that the PDF does
+            currently not account for the clipping at the bounds.
+        """
+        x = x if self.parameter_scale else unscale(x, self.transformation)
+
+        # scale the PDF to the parameter scale
+        if self.parameter_scale or self.transformation == C.LIN:
+            coeff = 1
+        elif self.transformation == C.LOG10:
+            coeff = x * np.log(10)
+        elif self.transformation == C.LOG:
+            coeff = x
+        else:
+            raise ValueError(f"Unknown transformation: {self.transformation}")
+
+        return self._pdf(x) * coeff
+
+    def neglogprior(self, x):
+        """Negative log-prior at x.
+
+        :param x: The value at which to evaluate the negative log-prior.
+            ``x`` is assumed to be on the parameter scale.
+        :return: The negative log-prior at ``x``.
+        """
+        return -np.log(self.pdf(x))
+
+    @staticmethod
+    def from_par_dict(
+        d, type_=Literal["initialization", "objective"]
+    ) -> Distribution:
+        """Create a distribution from a row of the parameter table.
+
+        :param d: A dictionary representing a row of the parameter table.
+        :param type_: The type of the distribution.
+        :return: A distribution object.
+        """
+        dist_type = d.get(f"{type_}PriorType", C.NORMAL)
+        if not isinstance(dist_type, str) and np.isnan(dist_type):
+            dist_type = C.PARAMETER_SCALE_UNIFORM
+        cls = Distribution._type_to_cls[dist_type]
+
+        pscale = d.get(C.PARAMETER_SCALE, C.LIN)
+        if (
+            pd.isna(d[f"{type_}PriorParameters"])
+            and dist_type == C.PARAMETER_SCALE_UNIFORM
+        ):
+            params = (
+                scale(d[C.LOWER_BOUND], pscale),
+                scale(d[C.UPPER_BOUND], pscale),
+            )
+        else:
+            params = tuple(
+                map(
+                    float,
+                    d[f"{type_}PriorParameters"].split(C.PARAMETER_SEPARATOR),
+                )
+            )
+        return cls(
+            *params,
+            bounds=(d[C.LOWER_BOUND], d[C.UPPER_BOUND]),
+            transformation=pscale,
+        )
+
+
+class Normal(Distribution):
+    """A normal distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+        _type=C.NORMAL,
+        _parameter_scale=False,
+    ):
+        super().__init__(
+            transformation=transformation,
+            parameters=(mean, std),
+            bounds=bounds,
+            parameter_scale=_parameter_scale,
+            type_=_type,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.normal(
+            loc=self.parameters[0], scale=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return norm.pdf(x, loc=self.parameters[0], scale=self.parameters[1])
+
+
+class LogNormal(Distribution):
+    """A log-normal distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.LOG_NORMAL,
+            transformation=transformation,
+            parameters=(mean, std),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.lognormal(
+            mean=self.parameters[0], sigma=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return lognorm.pdf(
+            x, scale=np.exp(self.parameters[0]), s=self.parameters[1]
+        )
+
+
+class Uniform(Distribution):
+    """A uniform distribution."""
+
+    def __init__(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+        _type=C.UNIFORM,
+        _parameter_scale=False,
+    ):
+        super().__init__(
+            _type,
+            transformation=transformation,
+            parameters=(lower_bound, upper_bound),
+            bounds=bounds,
+            parameter_scale=_parameter_scale,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.uniform(
+            low=self.parameters[0], high=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return uniform.pdf(
+            x,
+            loc=self.parameters[0],
+            scale=self.parameters[1] - self.parameters[0],
+        )
+
+
+class Laplace(Distribution):
+    """A Laplace distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        scale: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+        _type=C.LAPLACE,
+        _parameter_scale=False,
+    ):
+        super().__init__(
+            _type,
+            transformation=transformation,
+            parameters=(mean, scale),
+            bounds=bounds,
+            parameter_scale=_parameter_scale,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.laplace(
+            loc=self.parameters[0], scale=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return laplace.pdf(x, loc=self.parameters[0], scale=self.parameters[1])
+
+
+class LogLaplace(Distribution):
+    """A log-Laplace distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        scale: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.LOG_LAPLACE,
+            transformation=transformation,
+            parameters=(mean, scale),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    @property
+    def mean(self):
+        """The mean of the underlying Laplace distribution."""
+        return self.parameters[0]
+
+    @property
+    def scale(self):
+        """The scale of the underlying Laplace distribution."""
+        return self.parameters[1]
+
+    def sample(self, shape=None):
+        sample = np.exp(
+            np.random.laplace(loc=self.mean, scale=self.scale, size=shape)
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return (
+            1
+            / (2 * self.scale * x)
+            * np.exp(-np.abs(np.log(x) - self.mean) / self.scale)
+        )
+
+
+class ParameterScaleNormal(Normal):
+    """A normal distribution with parameters on the parameter scale."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            transformation=transformation,
+            bounds=bounds,
+            mean=mean,
+            std=std,
+            _type=C.PARAMETER_SCALE_NORMAL,
+            _parameter_scale=True,
+        )
+
+
+class ParameterScaleUniform(Uniform):
+    """A uniform distribution with parameters on the parameter scale."""
+
+    def __init__(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            transformation=transformation,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            bounds=bounds,
+            _type=C.PARAMETER_SCALE_UNIFORM,
+            _parameter_scale=True,
+        )
+
+
+class ParameterScaleLaplace(Laplace):
+    """A Laplace distribution with parameters on the parameter scale."""
+
+    def __init__(
+        self,
+        mean: float,
+        scale: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            _type=C.PARAMETER_SCALE_LAPLACE,
+            transformation=transformation,
+            mean=mean,
+            scale=scale,
+            bounds=bounds,
+            _parameter_scale=True,
+        )
+
+
+Distribution._type_to_cls = {
+    C.NORMAL: Normal,
+    C.LOG_NORMAL: LogNormal,
+    C.UNIFORM: Uniform,
+    C.LAPLACE: Laplace,
+    C.LOG_LAPLACE: LogLaplace,
+    C.PARAMETER_SCALE_NORMAL: ParameterScaleNormal,
+    C.PARAMETER_SCALE_UNIFORM: ParameterScaleUniform,
+    C.PARAMETER_SCALE_LAPLACE: ParameterScaleLaplace,
+}

--- a/petab/v1/parameters.py
+++ b/petab/v1/parameters.py
@@ -524,7 +524,8 @@ def scale(
     if scale_str == LOG:
         return np.log(parameter)
     if scale_str == LOG10:
-        return np.log10(parameter)
+        with np.errstate(divide="ignore"):
+            return np.log10(parameter)
     raise ValueError(f"Invalid parameter scaling: {scale_str}")
 
 

--- a/petab/v1/priors.py
+++ b/petab/v1/priors.py
@@ -97,21 +97,17 @@ class Prior:
             case (C.LAPLACE, _) | (C.PARAMETER_SCALE_LAPLACE, C.LIN):
                 self.distribution = Laplace(*parameters)
             case (C.PARAMETER_SCALE_UNIFORM, C.LOG):
-                self.distribution = LogUniform(*parameters)
+                self.distribution = Uniform(*parameters, log=True)
             case (C.LOG_NORMAL, _) | (C.PARAMETER_SCALE_NORMAL, C.LOG):
-                self.distribution = LogNormal(*parameters)
+                self.distribution = Normal(*parameters, log=True)
             case (C.LOG_LAPLACE, _) | (C.PARAMETER_SCALE_LAPLACE, C.LOG):
-                self.distribution = LogLaplace(*parameters)
+                self.distribution = Laplace(*parameters, log=True)
             case (C.PARAMETER_SCALE_UNIFORM, C.LOG10):
-                self.distribution = LogUniform(*parameters, base=10)
+                self.distribution = Uniform(*parameters, log=10)
             case (C.PARAMETER_SCALE_NORMAL, C.LOG10):
-                self.distribution = LogNormal(
-                    np.log(10) * parameters[0], np.log(10) * parameters[1]
-                )
+                self.distribution = Normal(*parameters, log=10)
             case (C.PARAMETER_SCALE_LAPLACE, C.LOG10):
-                self.distribution = LogLaplace(
-                    np.log(10) * parameters[0], np.log(10) * parameters[1]
-                )
+                self.distribution = Laplace(*parameters, log=10)
             case _:
                 raise ValueError(
                     "Unsupported distribution type / transformation: "

--- a/petab/v1/sampling.py
+++ b/petab/v1/sampling.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 import numpy as np
 import pandas as pd
 
-from . import parameters
 from .C import *  # noqa: F403
+from .distributions import Distribution
 
 __all__ = ["sample_from_prior", "sample_parameter_startpoints"]
 
@@ -26,84 +26,10 @@ def sample_from_prior(
     """
     # unpack info
     p_type, p_params, scaling, bounds = prior
+    prior_cls = Distribution._type_to_cls[p_type]
+    prior = prior_cls(*p_params, bounds=tuple(bounds), transformation=scaling)
 
-    # define a function to rescale the sampled points to parameter scale
-    def scale(x):
-        if scaling == LIN:
-            return x
-        if scaling == LOG:
-            return np.log(x)
-        if scaling == LOG10:
-            return np.log10(x)
-        raise NotImplementedError(
-            f"Parameter priors on the parameter scale {scaling} are "
-            "currently not implemented."
-        )
-
-    def clip_to_bounds(x: np.array):
-        """Clip values in array x to bounds"""
-        return np.maximum(np.minimum(scale(bounds[1]), x), scale(bounds[0]))
-
-    # define lambda functions for each parameter
-    if p_type == UNIFORM:
-        sp = scale(
-            (p_params[1] - p_params[0]) * np.random.random((n_starts,))
-            + p_params[0]
-        )
-
-    elif p_type == PARAMETER_SCALE_UNIFORM:
-        sp = (p_params[1] - p_params[0]) * np.random.random(
-            (n_starts,)
-        ) + p_params[0]
-
-    elif p_type == NORMAL:
-        sp = scale(
-            np.random.normal(
-                loc=p_params[0], scale=p_params[1], size=(n_starts,)
-            )
-        )
-
-    elif p_type == LOG_NORMAL:
-        sp = scale(
-            np.exp(
-                np.random.normal(
-                    loc=p_params[0], scale=p_params[1], size=(n_starts,)
-                )
-            )
-        )
-
-    elif p_type == PARAMETER_SCALE_NORMAL:
-        sp = np.random.normal(
-            loc=p_params[0], scale=p_params[1], size=(n_starts,)
-        )
-
-    elif p_type == LAPLACE:
-        sp = scale(
-            np.random.laplace(
-                loc=p_params[0], scale=p_params[1], size=(n_starts,)
-            )
-        )
-
-    elif p_type == LOG_LAPLACE:
-        sp = scale(
-            np.exp(
-                np.random.laplace(
-                    loc=p_params[0], scale=p_params[1], size=(n_starts,)
-                )
-            )
-        )
-
-    elif p_type == PARAMETER_SCALE_LAPLACE:
-        sp = np.random.laplace(
-            loc=p_params[0], scale=p_params[1], size=(n_starts,)
-        )
-
-    else:
-        raise NotImplementedError(
-            f"Parameter priors of type {prior[0]} are not implemented."
-        )
-
-    return clip_to_bounds(sp)
+    return prior.sample(shape=(n_starts,))
 
 
 def sample_parameter_startpoints(
@@ -130,11 +56,24 @@ def sample_parameter_startpoints(
     if seed is not None:
         np.random.seed(seed)
 
+    par_to_estimate = parameter_df.loc[parameter_df[ESTIMATE] == 1]
+
+    if parameter_ids is not None:
+        try:
+            par_to_estimate = par_to_estimate.loc[parameter_ids, :]
+        except KeyError as e:
+            missing_ids = set(parameter_ids) - set(par_to_estimate.index)
+            raise KeyError(
+                "Parameter table does not contain estimated parameter(s) "
+                f"{missing_ids}."
+            ) from e
+
     # get types and parameters of priors from dataframe
-    prior_list = parameters.get_priors_from_df(
-        parameter_df, mode=INITIALIZATION, parameter_ids=parameter_ids
-    )
-
-    startpoints = [sample_from_prior(prior, n_starts) for prior in prior_list]
-
-    return np.array(startpoints).T
+    return np.array(
+        [
+            Distribution.from_par_dict(row, type_="initialization").sample(
+                n_starts
+            )
+            for row in par_to_estimate.to_dict("records")
+        ]
+    ).T

--- a/petab/v1/sampling.py
+++ b/petab/v1/sampling.py
@@ -6,7 +6,6 @@ import numpy as np
 import pandas as pd
 
 from .C import *  # noqa: F403
-from .distributions import Distribution
 
 __all__ = ["sample_from_prior", "sample_parameter_startpoints"]
 
@@ -24,11 +23,13 @@ def sample_from_prior(
     Returns:
         Array with sampled values
     """
+    from .priors import Prior
+
     # unpack info
     p_type, p_params, scaling, bounds = prior
-    prior_cls = Distribution._type_to_cls[p_type]
-    prior = prior_cls(*p_params, bounds=tuple(bounds), transformation=scaling)
-
+    prior = Prior(
+        p_type, tuple(p_params), bounds=tuple(bounds), transformation=scaling
+    )
     return prior.sample(shape=(n_starts,))
 
 
@@ -53,6 +54,8 @@ def sample_parameter_startpoints(
         Array of sampled starting points with dimensions
         `n_startpoints` x `n_optimization_parameters`
     """
+    from .priors import Prior
+
     if seed is not None:
         np.random.seed(seed)
 
@@ -71,9 +74,7 @@ def sample_parameter_startpoints(
     # get types and parameters of priors from dataframe
     return np.array(
         [
-            Distribution.from_par_dict(row, type_="initialization").sample(
-                n_starts
-            )
+            Prior.from_par_dict(row, type_="initialization").sample(n_starts)
             for row in par_to_estimate.to_dict("records")
         ]
     ).T

--- a/tests/v1/test_distributions.py
+++ b/tests/v1/test_distributions.py
@@ -1,41 +1,42 @@
-from itertools import product
-
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from scipy.integrate import cumulative_trapezoid
-from scipy.stats import kstest
+from scipy.stats import (
+    kstest,
+    laplace,
+    loglaplace,
+    lognorm,
+    loguniform,
+    norm,
+    uniform,
+)
 
 from petab.v1.distributions import *
 from petab.v2.C import *
 
 
 @pytest.mark.parametrize(
-    "distribution, transform",
-    list(
-        product(
-            [
-                Normal(2, 1),
-                Normal(2, 1, log=True),
-                Normal(2, 1, log=10),
-                Uniform(2, 4),
-                Uniform(-2, 4, log=True),
-                Uniform(2, 4, log=10),
-                Laplace(1, 2),
-                Laplace(1, 0.5, log=True),
-            ],
-            [LIN, LOG, LOG10],
-        )
-    ),
+    "distribution",
+    [
+        Normal(2, 1),
+        Normal(2, 1, log=True),
+        Normal(2, 1, log=10),
+        Uniform(2, 4),
+        Uniform(-2, 4, log=True),
+        Uniform(2, 4, log=10),
+        Laplace(1, 2),
+        Laplace(1, 0.5, log=True),
+    ],
 )
-def test_sample_matches_pdf(distribution, transform):
+def test_sample_matches_pdf(distribution):
     """Test that the sample matches the PDF."""
     np.random.seed(1)
     N_SAMPLES = 10_000
-    distribution.transform = transform
     sample = distribution.sample(N_SAMPLES)
 
-    # pdf -> cdf
     def cdf(x):
+        # pdf -> cdf
         return cumulative_trapezoid(distribution.pdf(x), x)
 
     # Kolmogorov-Smirnov test to check if the sample is drawn from the CDF
@@ -49,3 +50,38 @@ def test_sample_matches_pdf(distribution, transform):
     #     plt.show()
 
     assert p > 0.05, (p, distribution)
+
+    # Test samples match scipy CDFs
+    reference_pdf = None
+    if isinstance(distribution, Normal) and distribution.logbase is False:
+        reference_pdf = norm.pdf(sample, distribution.loc, distribution.scale)
+    elif isinstance(distribution, Uniform) and distribution.logbase is False:
+        reference_pdf = uniform.pdf(
+            sample, distribution._low, distribution._high - distribution._low
+        )
+    elif isinstance(distribution, Laplace) and distribution.logbase is False:
+        reference_pdf = laplace.pdf(
+            sample, distribution.loc, distribution.scale
+        )
+    elif isinstance(distribution, Normal) and distribution.logbase == np.exp(
+        1
+    ):
+        reference_pdf = lognorm.pdf(
+            sample, scale=np.exp(distribution.loc), s=distribution.scale
+        )
+    elif isinstance(distribution, Uniform) and distribution.logbase == np.exp(
+        1
+    ):
+        reference_pdf = loguniform.pdf(
+            sample, np.exp(distribution._low), np.exp(distribution._high)
+        )
+    elif isinstance(distribution, Laplace) and distribution.logbase == np.exp(
+        1
+    ):
+        reference_pdf = loglaplace.pdf(
+            sample, c=1 / distribution.scale, scale=np.exp(distribution.loc)
+        )
+    if reference_pdf is not None:
+        assert_allclose(
+            distribution.pdf(sample), reference_pdf, rtol=1e-10, atol=1e-14
+        )

--- a/tests/v1/test_distributions.py
+++ b/tests/v1/test_distributions.py
@@ -17,11 +17,9 @@ from petab.v2.C import *
                 Normal(1, 1),
                 LogNormal(2, 1),
                 Uniform(2, 4),
+                LogUniform(1, 2),
                 Laplace(1, 2),
                 LogLaplace(1, 0.5),
-                ParameterScaleNormal(1, 1),
-                ParameterScaleLaplace(1, 2),
-                ParameterScaleUniform(1, 2),
             ],
             [LIN, LOG, LOG10],
         )

--- a/tests/v1/test_distributions.py
+++ b/tests/v1/test_distributions.py
@@ -1,0 +1,51 @@
+from itertools import product
+
+import numpy as np
+import pytest
+from scipy.integrate import cumulative_trapezoid
+from scipy.stats import kstest
+
+from petab.v1.distributions import *
+from petab.v2.C import *
+
+
+@pytest.mark.parametrize(
+    "distribution, transform",
+    list(
+        product(
+            [
+                Normal(1, 1),
+                LogNormal(2, 1),
+                Uniform(2, 4),
+                Laplace(1, 2),
+                LogLaplace(1, 0.5),
+                ParameterScaleNormal(1, 1),
+                ParameterScaleLaplace(1, 2),
+                ParameterScaleUniform(1, 2),
+            ],
+            [LIN, LOG, LOG10],
+        )
+    ),
+)
+def test_sample_matches_pdf(distribution, transform):
+    """Test that the sample matches the PDF."""
+    np.random.seed(1)
+    N_SAMPLES = 10_000
+    distribution.transform = transform
+    sample = distribution.sample(N_SAMPLES)
+
+    # pdf -> cdf
+    def cdf(x):
+        return cumulative_trapezoid(distribution.pdf(x), x)
+
+    # Kolmogorov-Smirnov test to check if the sample is drawn from the CDF
+    _, p = kstest(sample, cdf)
+
+    # if p < 0.05:
+    #     import matplotlib.pyplot as plt
+    #     plt.hist(sample, bins=100, density=True)
+    #     x = np.linspace(min(sample), max(sample), 100)
+    #     plt.plot(x, distribution.pdf(x))
+    #     plt.show()
+
+    assert p > 0.05, (p, distribution)

--- a/tests/v1/test_distributions.py
+++ b/tests/v1/test_distributions.py
@@ -14,12 +14,14 @@ from petab.v2.C import *
     list(
         product(
             [
-                Normal(1, 1),
-                LogNormal(2, 1),
+                Normal(2, 1),
+                Normal(2, 1, log=True),
+                Normal(2, 1, log=10),
                 Uniform(2, 4),
-                LogUniform(1, 2),
+                Uniform(-2, 4, log=True),
+                Uniform(2, 4, log=10),
                 Laplace(1, 2),
-                LogLaplace(1, 0.5),
+                Laplace(1, 0.5, log=True),
             ],
             [LIN, LOG, LOG10],
         )


### PR DESCRIPTION
Introduces `Prior` and `Distribution` classes for handling PEtab-specific prior distributions, and (PEtab-version-invariant) univariate probability distributions. Supports sampling from them, and evaluating negative log-priors (#312). Later on, this can be extended to noise models for measurements and computing loglikelihoods.
This also adds a notebook demonstrating the various prior options which are a common source confusion.

Closes #311.

:eyes: notebook: https://petab--329.org.readthedocs.build/projects/libpetab-python/en/329/example/distributions.html