### PR TITLE
Support for petab v2 experiments

### DIFF
--- a/petab/v1/calculate.py
+++ b/petab/v1/calculate.py
@@ -97,6 +97,9 @@ def calculate_residuals_for_table(
     Calculate residuals for a single measurement table.
     For the arguments, see `calculate_residuals`.
     """
+    # below, we rely on a unique index
+    measurement_df = measurement_df.reset_index(drop=True)
+
     # create residual df as copy of measurement df, change column
     residual_df = measurement_df.copy(deep=True).rename(
         columns={MEASUREMENT: RESIDUAL}
@@ -120,6 +123,10 @@ def calculate_residuals_for_table(
             for col in compared_cols
         ]
         mask = reduce(lambda x, y: x & y, masks)
+        if mask.sum() == 0:
+            raise ValueError(
+                f"Could not find simulation for measurement {row}."
+            )
         simulation = simulation_df.loc[mask][SIMULATION].iloc[0]
         if scale:
             # apply scaling

--- a/petab/v1/problem.py
+++ b/petab/v1/problem.py
@@ -1149,8 +1149,8 @@ class Problem:
         sim_cond_id: str,
         time: float,
         measurement: float,
-        observable_parameters: Sequence[str] = None,
-        noise_parameters: Sequence[str] = None,
+        observable_parameters: Sequence[str | float] = None,
+        noise_parameters: Sequence[str | float] = None,
         preeq_cond_id: str = None,
     ):
         """Add a measurement to the problem.
@@ -1172,11 +1172,11 @@ class Problem:
         }
         if observable_parameters is not None:
             record[OBSERVABLE_PARAMETERS] = [
-                PARAMETER_SEPARATOR.join(observable_parameters)
+                PARAMETER_SEPARATOR.join(map(str, observable_parameters))
             ]
         if noise_parameters is not None:
             record[NOISE_PARAMETERS] = [
-                PARAMETER_SEPARATOR.join(noise_parameters)
+                PARAMETER_SEPARATOR.join(map(str, noise_parameters))
             ]
         if preeq_cond_id is not None:
             record[PREEQUILIBRATION_CONDITION_ID] = [preeq_cond_id]

--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -22,6 +22,9 @@ TIME = "time"
 #: Time value that indicates steady-state measurements
 TIME_STEADY_STATE = _math.inf
 
+#: Time value that indicates pre-equilibration in the experiments table
+TIME_PREEQUILIBRATION = -_math.inf
+
 #: Observable parameters column in the measurement table
 OBSERVABLE_PARAMETERS = "observableParameters"
 

--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -13,14 +13,6 @@ OBSERVABLE_ID = "observableId"
 #: Experiment ID column in the measurement table
 EXPERIMENT_ID = "experimentId"
 
-# TODO: remove
-#: Preequilibration condition ID column in the measurement table
-PREEQUILIBRATION_CONDITION_ID = "preequilibrationConditionId"
-
-# TODO: remove
-#: Simulation condition ID column in the measurement table
-SIMULATION_CONDITION_ID = "simulationConditionId"
-
 #: Measurement value column in the measurement table
 MEASUREMENT = "measurement"
 
@@ -45,17 +37,13 @@ REPLICATE_ID = "replicateId"
 #: Mandatory columns of measurement table
 MEASUREMENT_DF_REQUIRED_COLS = [
     OBSERVABLE_ID,
-    # TODO: add
-    # EXPERIMENT_ID,
-    SIMULATION_CONDITION_ID,
+    EXPERIMENT_ID,
     MEASUREMENT,
     TIME,
 ]
 
 #: Optional columns of measurement table
 MEASUREMENT_DF_OPTIONAL_COLS = [
-    # TODO: remove
-    PREEQUILIBRATION_CONDITION_ID,
     OBSERVABLE_PARAMETERS,
     NOISE_PARAMETERS,
     DATASET_ID,

--- a/petab/v2/__init__.py
+++ b/petab/v2/__init__.py
@@ -27,7 +27,10 @@ warn(
 
 # import after v1
 from ..version import __version__  # noqa: F401, E402
-from . import models  # noqa: F401, E402
+from . import (  # noqa: F401, E402
+    C,  # noqa: F401, E402
+    models,  # noqa: F401, E402
+)
 from .conditions import *  # noqa: F403, F401, E402
 from .experiments import (  # noqa: F401, E402
     get_experiment_df,

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -131,7 +131,7 @@ def petab1to2(yaml_config: Path | str, output_dir: Path | str = None):
                     {
                         v2.C.EXPERIMENT_ID: exp_id,
                         v2.C.CONDITION_ID: preeq_cond_id,
-                        v2.C.TIME: float("-inf"),
+                        v2.C.TIME: v2.C.TIME_PREEQUILIBRATION,
                     }
                 )
             experiments.append(

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -4,8 +4,8 @@ from contextlib import suppress
 from itertools import chain
 from pathlib import Path
 from urllib.parse import urlparse
+from uuid import uuid4
 
-import numpy as np
 import pandas as pd
 from pandas.io.common import get_handle, is_url
 
@@ -98,10 +98,81 @@ def petab1to2(yaml_config: Path | str, output_dir: Path | str = None):
             condition_df = v1v2_condition_df(condition_df, petab_problem.model)
             v2.write_condition_df(condition_df, get_dest_path(condition_file))
 
+        # records for the experiment table to be created
+        experiments = []
+
+        def create_experiment_id(sim_cond_id: str, preeq_cond_id: str) -> str:
+            if not sim_cond_id and not preeq_cond_id:
+                return ""
+            if preeq_cond_id:
+                preeq_cond_id = f"{preeq_cond_id}_"
+            exp_id = f"experiment_{preeq_cond_id}{sim_cond_id}"
+            if exp_id in experiments:  # noqa: B023
+                i = 1
+                while f"{exp_id}_{i}" in experiments:  # noqa: B023
+                    i += 1
+                exp_id = f"{exp_id}_{i}"
+            return exp_id
+
+        measured_experiments = (
+            petab_problem.get_simulation_conditions_from_measurement_df()
+        )
+        for (
+            _,
+            row,
+        ) in measured_experiments.iterrows():
+            # generate a new experiment for each simulation / pre-eq condition
+            #  combination
+            sim_cond_id = row[v1.C.SIMULATION_CONDITION_ID]
+            preeq_cond_id = row.get(v1.C.PREEQUILIBRATION_CONDITION_ID, "")
+            exp_id = create_experiment_id(sim_cond_id, preeq_cond_id)
+            if preeq_cond_id:
+                experiments.append(
+                    {
+                        v2.C.EXPERIMENT_ID: exp_id,
+                        v2.C.CONDITION_ID: preeq_cond_id,
+                        v2.C.TIME: float("-inf"),
+                    }
+                )
+            experiments.append(
+                {
+                    v2.C.EXPERIMENT_ID: exp_id,
+                    v2.C.CONDITION_ID: sim_cond_id,
+                    v2.C.TIME: 0,
+                }
+            )
+        if experiments:
+            exp_table_path = output_dir / "experiments.tsv"
+            if exp_table_path.exists():
+                raise ValueError(
+                    f"Experiment table file {exp_table_path} already exists."
+                )
+            problem_config[v2.C.EXPERIMENT_FILES] = [exp_table_path.name]
+            v2.write_experiment_df(
+                v2.get_experiment_df(pd.DataFrame(experiments)), exp_table_path
+            )
+
         for measurement_file in problem_config.get(v2.C.MEASUREMENT_FILES, []):
             measurement_df = v1.get_measurement_df(
                 get_src_path(measurement_file)
             )
+            # if there is already an experiment ID column, we rename it
+            if v2.C.EXPERIMENT_ID in measurement_df.columns:
+                measurement_df.rename(
+                    columns={v2.C.EXPERIMENT_ID: f"experiment_id_{uuid4()}"},
+                    inplace=True,
+                )
+            # add pre-eq condition id if not present or convert to string
+            #  for simplicity
+            if v1.C.PREEQUILIBRATION_CONDITION_ID in measurement_df.columns:
+                measurement_df[
+                    v1.C.PREEQUILIBRATION_CONDITION_ID
+                ] = measurement_df[v1.C.PREEQUILIBRATION_CONDITION_ID].astype(
+                    str
+                )
+            else:
+                measurement_df[v1.C.PREEQUILIBRATION_CONDITION_ID] = ""
+
             if (
                 petab_problem.condition_df is not None
                 and len(
@@ -110,20 +181,33 @@ def petab1to2(yaml_config: Path | str, output_dir: Path | str = None):
                 )
                 == 0
             ):
-                # can't have "empty" conditions with no overrides in v2
-                # TODO: this needs to be done condition wise
-                measurement_df[v2.C.SIMULATION_CONDITION_ID] = np.nan
+                # we can't have "empty" conditions with no overrides in v2,
+                #  therefore, we drop the respective condition ID completely
+                #   TODO: or can we?
+                # TODO: this needs to be checked condition-wise, not globally
+                measurement_df[v1.C.SIMULATION_CONDITION_ID] = ""
                 if (
                     v1.C.PREEQUILIBRATION_CONDITION_ID
                     in measurement_df.columns
                 ):
-                    measurement_df[v2.C.PREEQUILIBRATION_CONDITION_ID] = np.nan
+                    measurement_df[v1.C.PREEQUILIBRATION_CONDITION_ID] = ""
+            # condition IDs to experiment IDs
+            measurement_df.insert(
+                0,
+                v2.C.EXPERIMENT_ID,
+                measurement_df.apply(
+                    lambda row: create_experiment_id(
+                        row[v1.C.SIMULATION_CONDITION_ID],
+                        row.get(v1.C.PREEQUILIBRATION_CONDITION_ID, ""),
+                    ),
+                    axis=1,
+                ),
+            )
+            del measurement_df[v1.C.SIMULATION_CONDITION_ID]
+            del measurement_df[v1.C.PREEQUILIBRATION_CONDITION_ID]
             v2.write_measurement_df(
                 measurement_df, get_dest_path(measurement_file)
             )
-    # TODO: Measurements: preequilibration to experiments/timecourses once
-    #  finalized
-    ...
 
     # validate updated Problem
     validation_issues = v2.lint_problem(new_yaml_file)
@@ -189,7 +273,7 @@ def v1v2_condition_df(
     """Convert condition table from petab v1 to v2."""
     condition_df = condition_df.copy().reset_index()
     with suppress(KeyError):
-        # TODO: are condition names still supported in v2?
+        # conditionName was dropped in PEtab v2
         condition_df.drop(columns=[v2.C.CONDITION_NAME], inplace=True)
 
     condition_df = condition_df.melt(

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -106,7 +106,7 @@ def petab1to2(yaml_config: Path | str, output_dir: Path | str = None):
                 return ""
             if preeq_cond_id:
                 preeq_cond_id = f"{preeq_cond_id}_"
-            exp_id = f"experiment_{preeq_cond_id}{sim_cond_id}"
+            exp_id = f"experiment__{preeq_cond_id}__{sim_cond_id}"
             if exp_id in experiments:  # noqa: B023
                 i = 1
                 while f"{exp_id}_{i}" in experiments:  # noqa: B023

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -30,7 +30,7 @@ def test_load_remote():
     """Test loading remote files"""
     yaml_url = (
         "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
-        "/update_v2/petabtests/cases/v2.0.0/sbml/0001/_0001.yaml"
+        "/update_v2/petabtests/cases/v2.0.0/sbml/0010/_0010.yaml"
     )
     petab_problem = Problem.from_yaml(yaml_url)
 
@@ -83,7 +83,7 @@ def test_problem_from_yaml_multiple_files():
                 problem.experiment_df, Path(tmpdir, f"experiments{i}.tsv")
             )
 
-            problem.add_measurement(f"observable{i}", f"condition{i}", 1, 1)
+            problem.add_measurement(f"observable{i}", f"experiment{i}", 1, 1)
             petab.write_measurement_df(
                 problem.measurement_df, Path(tmpdir, f"measurements{i}.tsv")
             )


### PR DESCRIPTION
Add basic support for PEtab version 2 experiments (see also https://github.com/PEtab-dev/PEtab/issues/586, and  https://github.com/PEtab-dev/PEtab/pull/581). Follow-up to #334.

Partially supersedes #263, which was started before petab.v1/petab.v2 were introduced and before https://github.com/PEtab-dev/PEtab/issues/586.

* updates the required fields in the measurement table
* updates some validation functions to not expect the old `simulationConditionId`s (but does not do full validation yet)
* extends PEtab v1 up-conversion to create a new experiment table.
