### PR TITLE
Sbml model enhancements

### DIFF
--- a/petab/v1/models/sbml_model.py
+++ b/petab/v1/models/sbml_model.py
@@ -80,7 +80,7 @@ class SbmlModel(Model):
             sbml_document=sbml_document,
             model_id=model_id,
         )
-    
+
     @staticmethod
     def from_string(sbml_string, model_id: str = None):
         sbml_reader, sbml_document, sbml_model = load_sbml_from_string(

--- a/petab/v1/models/sbml_model.py
+++ b/petab/v1/models/sbml_model.py
@@ -80,6 +80,22 @@ class SbmlModel(Model):
             sbml_document=sbml_document,
             model_id=model_id,
         )
+    
+    @staticmethod
+    def from_string(sbml_string, model_id: str = None):
+        sbml_reader, sbml_document, sbml_model = load_sbml_from_string(
+            sbml_string
+        )
+
+        if not model_id:
+            model_id = sbml_model.getIdAttribute()
+
+        return SbmlModel(
+            sbml_model=sbml_model,
+            sbml_reader=sbml_reader,
+            sbml_document=sbml_document,
+            model_id=model_id,
+        )
 
     @property
     def model_id(self):

--- a/petab/v1/sbml.py
+++ b/petab/v1/sbml.py
@@ -46,8 +46,9 @@ def is_sbml_consistent(
     has_issues = sbml_document.checkConsistency()
 
     # we only have an issue with errors or fatals
-    has_problems = sbml_document.getNumErrors(libsbml.LIBSBML_SEV_ERROR) + \
-                   sbml_document.getNumErrors(libsbml.LIBSBML_SEV_FATAL)
+    has_problems = sbml_document.getNumErrors(
+        libsbml.LIBSBML_SEV_ERROR
+    ) + sbml_document.getNumErrors(libsbml.LIBSBML_SEV_FATAL)
     if has_issues:
         log_sbml_errors(sbml_document)
         if has_problems:

--- a/petab/v1/sbml.py
+++ b/petab/v1/sbml.py
@@ -43,12 +43,17 @@ def is_sbml_consistent(
             libsbml.LIBSBML_CAT_UNITS_CONSISTENCY, False
         )
 
-    has_problems = sbml_document.checkConsistency()
-    if has_problems:
+    has_issues = sbml_document.checkConsistency()
+
+    # we only have an issue with errors or fatals
+    has_problems = sbml_document.getNumErrors(libsbml.LIBSBML_SEV_ERROR) + \
+                   sbml_document.getNumErrors(libsbml.LIBSBML_SEV_FATAL)
+    if has_issues:
         log_sbml_errors(sbml_document)
-        logger.warning(
-            "WARNING: Generated invalid SBML model. Check messages above."
-        )
+        if has_problems:
+            logger.warning(
+                "WARNING: Generated invalid SBML model. Check messages above."
+            )
 
     return not has_problems
 


### PR DESCRIPTION
This PR allows to create SBML models from string, but more critically considers an SBML model with warnings still as valid SbmlModel. The current PEtab implementation considers a file with warnings as invalid SBML, which is not the case. 