### PR TITLE
Implement proper truncation for prior distributions

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -10,6 +10,7 @@ The following examples should help to get a better idea of how to use the PEtab 
 
    example/example_petablint.ipynb
    example/example_visualization.ipynb
+   example/distributions.ipynb
 
 Examples of systems biology parameter estimation problems specified in PEtab
 can be found in the `systems biology benchmark model collection <https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab>`_.

--- a/doc/example/distributions.ipynb
+++ b/doc/example/distributions.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# Prior distributions in PEtab\n",
+    "\n",
+    "This notebook gives a brief overview of the prior distributions in PEtab and how they are represented in the PEtab library.\n",
+    "\n",
+    "Prior distributions are used to specify the prior knowledge about the parameters.\n",
+    "Parameter priors are specified in the parameter table. A prior is defined by its type and its parameters.\n",
+    "Each prior type has a specific set of parameters. For example, the normal distribution has two parameters: the mean and the standard deviation.\n",
+    "\n",
+    "There are two types of priors in PEtab - objective priors and initialization priors:\n",
+    "\n",
+    "* *Objective priors* are used to specify the prior knowledge about the parameters that are to be estimated. They will enter the objective function of the optimization problem. They are specified in the `objectivePriorType` and `objectivePriorParameters` columns of the parameter table.\n",
+    "* *Initialization priors* can be used as a hint for the optimization algorithm. They will not enter the objective function. They are specified in the `initializationPriorType` and `initializationPriorParameters` columns of the parameter table.\n",
+    "\n",
+    "\n"
+   ],
+   "id": "372289411a2aa7b3"
+  },
+  {
+   "metadata": {
+    "collapsed": true
+   },
+   "cell_type": "code",
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from petab.v1.C import *\n",
+    "from petab.v1.distributions import *\n",
+    "\n",
+    "sns.set_style(None)\n",
+    "\n",
+    "\n",
+    "def plot(distr: Distribution, ax=None):\n",
+    "    \"\"\"Visualize a distribution.\"\"\"\n",
+    "    if ax is None:\n",
+    "        fig, ax = plt.subplots()\n",
+    "\n",
+    "    sample = distr.sample(10000)\n",
+    "\n",
+    "    # pdf\n",
+    "    xmin = min(sample.min(), distr.lb_scaled if distr.bounds is not None else sample.min())\n",
+    "    xmax = max(sample.max(), distr.ub_scaled if distr.bounds is not None else sample.max())\n",
+    "    x = np.linspace(xmin, xmax, 500)\n",
+    "    y = distr.pdf(x)\n",
+    "    ax.plot(x, y, color='red', label='pdf')\n",
+    "\n",
+    "    sns.histplot(sample, stat='density', ax=ax, label=\"sample\")\n",
+    "\n",
+    "    # bounds\n",
+    "    if distr.bounds is not None:\n",
+    "        for bound in (distr.lb_scaled, distr.ub_scaled):\n",
+    "            if bound is not None and np.isfinite(bound):\n",
+    "                ax.axvline(bound, color='black', linestyle='--', label='bound')\n",
+    "\n",
+    "    ax.set_title(str(distr))\n",
+    "    ax.set_xlabel('Parameter value on the parameter scale')\n",
+    "    ax.grid(False)\n",
+    "    handles, labels = ax.get_legend_handles_labels()\n",
+    "    unique_labels = dict(zip(labels, handles))\n",
+    "    ax.legend(unique_labels.values(), unique_labels.keys())\n",
+    "    plt.show()"
+   ],
+   "id": "initial_id",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "The basic distributions are the uniform, normal, Laplace, log-normal, and log-laplace distributions:\n",
+   "id": "db36a4a93622ccb8"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Uniform(0, 1))\n",
+    "plot(Normal(0, 1))\n",
+    "plot(Laplace(0, 1))\n",
+    "plot(LogNormal(0, 1))\n",
+    "plot(LogLaplace(1, 0.5))"
+   ],
+   "id": "4f09e50a3db06d9f",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "If a parameter scale is specified, the sample is transformed accordingly (but not the distribution parameters):\n",
+   "id": "dab4b2d1e0f312d8"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Normal(10, 2, transformation=LIN))\n",
+    "plot(Normal(10, 2, transformation=LOG))\n",
+    "# Note that the log-normal is different from the log-transformed normal distribution:\n",
+    "plot(LogNormal(10, 2, transformation=LIN))"
+   ],
+   "id": "f6192c226f179ef9",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Prior distributions can also be defined on the parameter scale by using the types `parameterScaleUniform`, `parameterScaleNormal` or `parameterScaleLaplace`. In these cases, a sample from the given distribution is used directly, without applying any transformation according to `parameterScale` (this implies, that for `parameterScale=lin`, there is no difference between `parameterScaleUniform` and `uniform`):",
+   "id": "263c9fd31156a4d5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Uniform(0, 1, transformation=LOG10))\n",
+    "plot(ParameterScaleUniform(0, 1, transformation=LOG10))\n",
+    "\n",
+    "plot(Uniform(0, 1, transformation=LIN))\n",
+    "plot(ParameterScaleUniform(0, 1, transformation=LIN))\n"
+   ],
+   "id": "5ca940bc24312fc6",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "To prevent the sampled parameters from exceeding the bounds, the sampled parameters are clipped to the bounds. The bounds are defined in the parameter table. Note that the current implementation does not support sampling from a truncated distribution. Instead, the samples are clipped to the bounds. This may introduce unwanted bias, and thus, should only be used with caution (i.e., the bounds should be chosen wide enough):",
+   "id": "b1a8b17d765db826"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Normal(0, 1, bounds=(-4, 4)))  # negligible clipping-bias at 4 sigma\n",
+    "plot(Uniform(0, 1, bounds=(0.1, 0.9)))  # significant clipping-bias"
+   ],
+   "id": "4ac42b1eed759bdd",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Further distribution examples:",
+   "id": "45ffce1341483f24"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "plot(Normal(10, 1, bounds=(6, 14), transformation=\"log10\"))\n",
+    "plot(ParameterScaleNormal(10, 1, bounds=(10**6, 10**14), transformation=\"log10\"))\n"
+   ],
+   "id": "581e1ac431860419",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "",
+   "id": "802a64be56a6c94f",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/example/distributions.ipynb
+++ b/doc/example/distributions.ipynb
@@ -42,7 +42,7 @@
     "    if ax is None:\n",
     "        fig, ax = plt.subplots()\n",
     "\n",
-    "    sample = distr.sample(10000)\n",
+    "    sample = distr.sample(20_000)\n",
     "\n",
     "    # pdf\n",
     "    xmin = min(sample.min(), distr.lb_scaled if distr.bounds is not None else sample.min())\n",
@@ -102,9 +102,8 @@
    "cell_type": "code",
    "source": [
     "plot(Normal(10, 2, transformation=LIN))\n",
-    "plot(Normal(10, 2, transformation=LOG))\n",
-    "# Note that the log-normal is different from the log-transformed normal distribution:\n",
-    "plot(LogNormal(10, 2, transformation=LIN))"
+    "# Note that log-transformed normal distribution is different from the log-normal distribution\n",
+    "plot(Normal(10, 2, transformation=LOG))"
    ],
    "id": "f6192c226f179ef9",
    "outputs": [],
@@ -120,11 +119,13 @@
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Uniform(0, 1, transformation=LOG10))\n",
-    "plot(ParameterScaleUniform(0, 1, transformation=LOG10))\n",
+    "# different, because transformation!=LIN\n",
+    "plot(Uniform(1e-16, 1, transformation=LOG10))\n",
+    "plot(ParameterScaleUniform(1e-16, 1, transformation=LOG10))\n",
     "\n",
-    "plot(Uniform(0, 1, transformation=LIN))\n",
-    "plot(ParameterScaleUniform(0, 1, transformation=LIN))\n"
+    "# same, because transformation=LIN\n",
+    "plot(Uniform(1e-16, 1, transformation=LIN))\n",
+    "plot(ParameterScaleUniform(1e-16, 1, transformation=LIN))\n"
    ],
    "id": "5ca940bc24312fc6",
    "outputs": [],
@@ -133,15 +134,18 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "To prevent the sampled parameters from exceeding the bounds, the sampled parameters are clipped to the bounds. The bounds are defined in the parameter table. Note that the current implementation does not support sampling from a truncated distribution. Instead, the samples are clipped to the bounds. This may introduce unwanted bias, and thus, should only be used with caution (i.e., the bounds should be chosen wide enough):",
+   "source": "The given distributions are truncated at the bounds defined in the parameter table:",
    "id": "b1a8b17d765db826"
   },
   {
    "metadata": {},
    "cell_type": "code",
    "source": [
-    "plot(Normal(0, 1, bounds=(-4, 4)))  # negligible clipping-bias at 4 sigma\n",
-    "plot(Uniform(0, 1, bounds=(0.1, 0.9)))  # significant clipping-bias"
+    "plot(Normal(0, 1, bounds=(-2, 2)))\n",
+    "plot(Uniform(0, 1, bounds=(0.1, 0.9)))\n",
+    "plot(Uniform(1e-8, 1, bounds=(0.1, 0.9), transformation=LOG10))\n",
+    "plot(Laplace(0, 1, bounds=(-0.5, 0.5)))\n",
+    "plot(ParameterScaleUniform(-3, 1, bounds=(1e-2, 1), transformation=LOG10))\n"
    ],
    "id": "4ac42b1eed759bdd",
    "outputs": [],
@@ -156,10 +160,7 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": [
-    "plot(Normal(10, 1, bounds=(6, 14), transformation=\"log10\"))\n",
-    "plot(ParameterScaleNormal(10, 1, bounds=(10**6, 10**14), transformation=\"log10\"))\n"
-   ],
+   "source": "plot(Normal(10, 1, bounds=(6, 14), transformation=\"log10\"))",
    "id": "581e1ac431860419",
    "outputs": [],
    "execution_count": null
@@ -167,8 +168,24 @@
   {
    "metadata": {},
    "cell_type": "code",
-   "source": "",
+   "source": "plot(ParameterScaleNormal(10, 1, bounds=(10**6, 10**14), transformation=\"log10\"))",
+   "id": "99202ecb47706a68",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "plot(LogLaplace(1, 0.5, bounds=(0.5, 8)))",
    "id": "802a64be56a6c94f",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "plot(LogNormal(2, 1, bounds=(0.5, 8)))",
+   "id": "7820e93ab9b2fb47",
    "outputs": [],
    "execution_count": null
   }

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -14,6 +14,7 @@ API Reference
    petab.v1.composite_problem
    petab.v1.conditions
    petab.v1.core
+   petab.v1.distributions
    petab.v1.lint
    petab.v1.measurements
    petab.v1.models

--- a/petab/v1/distributions.py
+++ b/petab/v1/distributions.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
-from scipy.stats import laplace, lognorm, norm, uniform
+from scipy.stats import laplace, lognorm, norm, truncnorm, uniform
 
 from . import C
 from .parameters import scale, unscale
@@ -38,7 +38,6 @@ class Distribution(abc.ABC):
         If `True`, the parameters are assumed to be on the correct scale and
         no transformation is applied.
     :param transformation: The transformation of the distribution.
-
     """
 
     _type_to_cls: dict[str, type[Distribution]] = {}
@@ -64,19 +63,47 @@ class Distribution(abc.ABC):
                 f"Expected two bounds, got {len(bounds)}: {bounds}"
             )
 
-        self.type = type_
-        self.parameters = parameters
-        self.bounds = bounds
-        self.transformation = transformation
-        self.parameter_scale = parameter_scale
+        self._type = type_
+        self._parameters = parameters
+        self._bounds = bounds
+        self._transformation = transformation
+        self._parameter_scale = parameter_scale
+        # normalization factor for pdf/cdf of truncated distributions
+        self._truncation_normalizer = 1
+        # lower and upper bounds on the same scale as the `distribution`
+        #  parameters (not necessarily the PEtab parameter scale)
+        self._low = None
+        self._high = None
+
+        if self._bounds is not None:
+            self._low = (
+                self.lb_scaled if self._parameter_scale else self._bounds[0]
+            )
+            self._high = (
+                self.ub_scaled if self._parameter_scale else self._bounds[1]
+            )
+            try:
+                self._cd_low = self._cdf_unscaled_untruncated(self._low)
+                self._cd_high = self._cdf_unscaled_untruncated(self._high)
+                self._truncation_normalizer = 1 / (
+                    self._cd_high - self._cd_low
+                )
+            except NotImplementedError:
+                pass
 
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
-            f"{self.parameters[0]!r}, {self.parameters[1]!r},"
-            f" bounds={self.bounds!r}, transformation={self.transformation!r}"
+            f"{self._parameters[0]!r}, {self._parameters[1]!r},"
+            f" bounds={self._bounds!r}, "
+            f"transformation={self._transformation!r}"
             ")"
         )
+
+    @property
+    def bounds(self):
+        """The bounds of the distribution."""
+        return self._bounds
 
     @abc.abstractmethod
     def sample(self, shape=None) -> np.ndarray:
@@ -89,34 +116,20 @@ class Distribution(abc.ABC):
 
     def _scale_sample(self, sample):
         """Scale the sample to the parameter space"""
-        if self.parameter_scale:
+        if self._parameter_scale:
             return sample
 
-        return scale(sample, self.transformation)
-
-    def _clip_to_bounds(self, x):
-        """Clip `x` values to bounds.
-
-        :param x: The values to clip. Assumed to be on the parameter scale.
-        """
-        # TODO: replace this by proper truncation
-        if self.bounds is None:
-            return x
-
-        return np.maximum(
-            np.minimum(self.ub_scaled, x),
-            self.lb_scaled,
-        )
+        return scale(sample, self._transformation)
 
     @property
     def lb_scaled(self):
         """The lower bound on the parameter scale."""
-        return scale(self.bounds[0], self.transformation)
+        return scale(self._bounds[0], self._transformation)
 
     @property
     def ub_scaled(self):
         """The upper bound on the parameter scale."""
-        return scale(self.bounds[1], self.transformation)
+        return scale(self._bounds[1], self._transformation)
 
     @abc.abstractmethod
     def _pdf(self, x):
@@ -128,27 +141,64 @@ class Distribution(abc.ABC):
         """
         ...
 
+    def _cdf(self, x):
+        """Cumulative distribution function at x.
+
+        :param x: The value at which to evaluate the CDF.
+            ``x`` is assumed to be on the linear scale.
+        :return: The value of the CDF at ``x``.
+        """
+        raise NotImplementedError
+
+    def _cdf_unscaled_untruncated(self, x):
+        """Cumulative distribution function at x, ignoring scale and bounds.
+
+        :param x: The value at which to evaluate the CDF.
+            ``x`` is assumed to be on the parameter scale.
+        :return: The value of the CDF at ``x``.
+        """
+        raise NotImplementedError
+
     def pdf(self, x):
         """Probability density function at x.
 
         :param x: The value at which to evaluate the PDF.
             ``x`` is assumed to be on the parameter scale.
-        :return: The value of the PDF at ``x``. Note that the PDF does
-            currently not account for the clipping at the bounds.
+        :return: The value of the PDF at ``x``.
         """
-        x = x if self.parameter_scale else unscale(x, self.transformation)
+        x = x if self._parameter_scale else unscale(x, self._transformation)
 
         # scale the PDF to the parameter scale
-        if self.parameter_scale or self.transformation == C.LIN:
+        if self._parameter_scale or self._transformation == C.LIN:
             coeff = 1
-        elif self.transformation == C.LOG10:
+        elif self._transformation == C.LOG10:
             coeff = x * np.log(10)
-        elif self.transformation == C.LOG:
+        elif self._transformation == C.LOG:
             coeff = x
         else:
-            raise ValueError(f"Unknown transformation: {self.transformation}")
+            raise ValueError(f"Unknown transformation: {self._transformation}")
 
         return self._pdf(x) * coeff
+
+    def _ppf_unscaled_untruncated(self, q):
+        """Percent point function at q, ignoring scale and bounds.
+
+        :param q: The quantile at which to evaluate the PPF.
+        :return: The value of the PPF at ``q``.
+        """
+        raise NotImplementedError
+
+    def _inverse_transform_sample(self, shape):
+        """Generate an inverse transform sample for the unscaled,
+        untruncated distribution.
+
+        :param shape: The shape of the sample.
+        :return: The sample.
+        """
+        uniform_sample = np.random.uniform(
+            low=self._cd_low, high=self._cd_high, size=shape
+        )
+        return self._ppf_unscaled_untruncated(uniform_sample)
 
     def neglogprior(self, x):
         """Negative log-prior at x.
@@ -206,23 +256,45 @@ class Normal(Distribution):
         std: float,
         bounds: tuple = None,
         transformation: str = C.LIN,
+        _type=C.NORMAL,
+        _parameter_scale=False,
     ):
         super().__init__(
-            C.NORMAL,
             transformation=transformation,
             parameters=(mean, std),
             bounds=bounds,
-            parameter_scale=False,
+            parameter_scale=_parameter_scale,
+            type_=_type,
         )
 
     def sample(self, shape=None):
-        sample = np.random.normal(
-            loc=self.parameters[0], scale=self.parameters[1], size=shape
-        )
-        return self._clip_to_bounds(self._scale_sample(sample))
+        if self._bounds is None:
+            sample = np.random.normal(
+                loc=self._parameters[0], scale=self._parameters[1], size=shape
+            )
+        else:
+            sample = truncnorm.rvs(
+                a=(self._low - self._parameters[0]) / self._parameters[1],
+                b=(self._high - self._parameters[0]) / self._parameters[1],
+                loc=self._parameters[0],
+                scale=self._parameters[1],
+                size=shape,
+            )
+        return self._scale_sample(sample)
 
     def _pdf(self, x):
-        return norm.pdf(x, loc=self.parameters[0], scale=self.parameters[1])
+        if self._bounds is None:
+            return norm.pdf(
+                x, loc=self._parameters[0], scale=self._parameters[1]
+            )
+
+        return truncnorm.pdf(
+            x,
+            a=(self._low - self._parameters[0]) / self._parameters[1],
+            b=(self._high - self._parameters[0]) / self._parameters[1],
+            loc=self._parameters[0],
+            scale=self._parameters[1],
+        )
 
 
 class LogNormal(Distribution):
@@ -244,14 +316,30 @@ class LogNormal(Distribution):
         )
 
     def sample(self, shape=None):
-        sample = np.random.lognormal(
-            mean=self.parameters[0], sigma=self.parameters[1], size=shape
-        )
-        return self._clip_to_bounds(self._scale_sample(sample))
+        if self._bounds is None:
+            sample = np.random.lognormal(
+                mean=self._parameters[0], sigma=self._parameters[1], size=shape
+            )
+        else:
+            sample = self._inverse_transform_sample(shape)
+        return self._scale_sample(sample)
 
     def _pdf(self, x):
-        return lognorm.pdf(
-            x, scale=np.exp(self.parameters[0]), s=self.parameters[1]
+        return (
+            lognorm.pdf(
+                x, scale=np.exp(self._parameters[0]), s=self._parameters[1]
+            )
+            * self._truncation_normalizer
+        )
+
+    def _cdf_unscaled_untruncated(self, x):
+        return lognorm.cdf(
+            x, scale=np.exp(self._parameters[0]), s=self._parameters[1]
+        )
+
+    def _ppf_unscaled_untruncated(self, q):
+        return lognorm.ppf(
+            q, scale=np.exp(self._parameters[0]), s=self._parameters[1]
         )
 
 
@@ -264,26 +352,48 @@ class Uniform(Distribution):
         upper_bound: float,
         bounds: tuple = None,
         transformation: str = C.LIN,
+        _type=C.UNIFORM,
+        _parameter_scale=False,
     ):
         super().__init__(
-            C.UNIFORM,
+            _type,
             transformation=transformation,
             parameters=(lower_bound, upper_bound),
             bounds=bounds,
-            parameter_scale=False,
+            parameter_scale=_parameter_scale,
         )
+
+    def _low_high(self):
+        """Get the lower and upper bounds of the distribution.
+
+        Consider the bounds of the distribution and the parameter bounds.
+        The values are not scaled, unless `parameter_scale` is `True`.
+        """
+        if self._bounds is None:
+            return self._parameters
+
+        low = max(
+            self._parameters[0],
+            self.lb_scaled if self._parameter_scale else self._bounds[0],
+        )
+        high = min(
+            self._parameters[1],
+            self.ub_scaled if self._parameter_scale else self._bounds[1],
+        )
+
+        return low, high
 
     def sample(self, shape=None):
-        sample = np.random.uniform(
-            low=self.parameters[0], high=self.parameters[1], size=shape
-        )
-        return self._clip_to_bounds(self._scale_sample(sample))
+        low, high = self._low_high()
+        sample = np.random.uniform(low=low, high=high, size=shape)
+        return self._scale_sample(sample)
 
     def _pdf(self, x):
+        low, high = self._low_high()
         return uniform.pdf(
             x,
-            loc=self.parameters[0],
-            scale=self.parameters[1] - self.parameters[0],
+            loc=low,
+            scale=high - low,
         )
 
 
@@ -296,23 +406,48 @@ class Laplace(Distribution):
         scale: float,
         bounds: tuple = None,
         transformation: str = C.LIN,
+        _type=C.LAPLACE,
+        _parameter_scale=False,
     ):
         super().__init__(
-            C.LAPLACE,
+            _type,
             transformation=transformation,
             parameters=(mean, scale),
             bounds=bounds,
-            parameter_scale=False,
+            parameter_scale=_parameter_scale,
         )
 
     def sample(self, shape=None):
-        sample = np.random.laplace(
-            loc=self.parameters[0], scale=self.parameters[1], size=shape
-        )
-        return self._clip_to_bounds(self._scale_sample(sample))
+        if self._bounds is None:
+            sample = np.random.laplace(
+                loc=self._parameters[0], scale=self._parameters[1], size=shape
+            )
+        else:
+            sample = self._inverse_transform_sample(shape)
+        return self._scale_sample(sample)
 
     def _pdf(self, x):
-        return laplace.pdf(x, loc=self.parameters[0], scale=self.parameters[1])
+        return (
+            laplace.pdf(x, loc=self._parameters[0], scale=self._parameters[1])
+            * self._truncation_normalizer
+        )
+
+    def _cdf_unscaled_untruncated(self, x):
+        return laplace.cdf(
+            x, loc=self._parameters[0], scale=self._parameters[1]
+        )
+
+    def _cdf_unscaled_truncated(self, x):
+        if self._bounds is None:
+            return self._cdf_unscaled_untruncated(x)
+
+        cd_untruncated = self._cdf_unscaled_untruncated(x)
+        return (cd_untruncated - self._cd_low) * self._truncation_normalizer
+
+    def _ppf_unscaled_untruncated(self, q):
+        return laplace.ppf(
+            q, loc=self._parameters[0], scale=self._parameters[1]
+        )
 
 
 class LogLaplace(Distribution):
@@ -336,28 +471,42 @@ class LogLaplace(Distribution):
     @property
     def mean(self):
         """The mean of the underlying Laplace distribution."""
-        return self.parameters[0]
+        return self._parameters[0]
 
     @property
     def scale(self):
         """The scale of the underlying Laplace distribution."""
-        return self.parameters[1]
+        return self._parameters[1]
 
     def sample(self, shape=None):
-        sample = np.exp(
-            np.random.laplace(loc=self.mean, scale=self.scale, size=shape)
-        )
-        return self._clip_to_bounds(self._scale_sample(sample))
+        if self._bounds is None:
+            sample = np.exp(
+                np.random.laplace(loc=self.mean, scale=self.scale, size=shape)
+            )
+        else:
+            sample = self._inverse_transform_sample(shape)
+
+        return self._scale_sample(sample)
 
     def _pdf(self, x):
         return (
             1
             / (2 * self.scale * x)
             * np.exp(-np.abs(np.log(x) - self.mean) / self.scale)
+        ) * self._truncation_normalizer
+
+    def _cdf_unscaled_untruncated(self, x):
+        return laplace.cdf(
+            np.log(x), loc=self._parameters[0], scale=self._parameters[1]
+        )
+
+    def _ppf_unscaled_untruncated(self, q):
+        return np.exp(
+            laplace.ppf(q, loc=self._parameters[0], scale=self._parameters[1])
         )
 
 
-class ParameterScaleNormal(Distribution):
+class ParameterScaleNormal(Normal):
     """A normal distribution with parameters on the parameter scale."""
 
     def __init__(
@@ -368,18 +517,16 @@ class ParameterScaleNormal(Distribution):
         transformation: str = C.LIN,
     ):
         super().__init__(
-            C.PARAMETER_SCALE_NORMAL,
             transformation=transformation,
-            parameters=(mean, std),
+            mean=mean,
+            std=std,
             bounds=bounds,
-            parameter_scale=True,
+            _type=C.PARAMETER_SCALE_NORMAL,
+            _parameter_scale=True,
         )
 
-    sample = Normal.sample
-    _pdf = Normal._pdf
 
-
-class ParameterScaleUniform(Distribution):
+class ParameterScaleUniform(Uniform):
     """A uniform distribution with parameters on the parameter scale."""
 
     def __init__(
@@ -390,18 +537,16 @@ class ParameterScaleUniform(Distribution):
         transformation: str = C.LIN,
     ):
         super().__init__(
-            C.PARAMETER_SCALE_UNIFORM,
             transformation=transformation,
-            parameters=(lower_bound, upper_bound),
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
             bounds=bounds,
-            parameter_scale=True,
+            _type=C.PARAMETER_SCALE_UNIFORM,
+            _parameter_scale=True,
         )
 
-    sample = Uniform.sample
-    _pdf = Uniform._pdf
 
-
-class ParameterScaleLaplace(Distribution):
+class ParameterScaleLaplace(Laplace):
     """A Laplace distribution with parameters on the parameter scale."""
 
     def __init__(
@@ -412,15 +557,13 @@ class ParameterScaleLaplace(Distribution):
         transformation: str = C.LIN,
     ):
         super().__init__(
-            C.PARAMETER_SCALE_LAPLACE,
+            _type=C.PARAMETER_SCALE_LAPLACE,
             transformation=transformation,
-            parameters=(mean, scale),
+            mean=mean,
+            scale=scale,
             bounds=bounds,
-            parameter_scale=True,
+            _parameter_scale=True,
         )
-
-    sample = Laplace.sample
-    _pdf = Laplace._pdf
 
 
 Distribution._type_to_cls = {

--- a/petab/v1/distributions.py
+++ b/petab/v1/distributions.py
@@ -1,0 +1,435 @@
+"""Probability distributions used by PEtab."""
+from __future__ import annotations
+
+import abc
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+from scipy.stats import laplace, lognorm, norm, uniform
+
+from . import C
+from .parameters import scale, unscale
+
+__all__ = [
+    "Distribution",
+    "Normal",
+    "LogNormal",
+    "Uniform",
+    "Laplace",
+    "LogLaplace",
+    "ParameterScaleNormal",
+    "ParameterScaleUniform",
+    "ParameterScaleLaplace",
+]
+
+
+class Distribution(abc.ABC):
+    """A univariate probability distribution.
+
+    :param type_: The type of the distribution.
+    :param transformation: The transformation to be applied to the sample.
+        Ignored if `parameter_scale` is `True`.
+    :param parameters: The parameters of the distribution (unaffected by
+        `parameter_scale` and `transformation`).
+    :param bounds: The untransformed bounds of the sample (lower, upper).
+    :param parameter_scale: Whether the parameters are already on the correct
+        scale. If `False`, the parameters are transformed to the correct scale.
+        If `True`, the parameters are assumed to be on the correct scale and
+        no transformation is applied.
+    :param transformation: The transformation of the distribution.
+
+    """
+
+    _type_to_cls: dict[str, type[Distribution]] = {}
+
+    def __init__(
+        self,
+        type_: str,
+        transformation: str,
+        parameters: tuple,
+        bounds: tuple = None,
+        parameter_scale: bool = False,
+    ):
+        if type_ not in self._type_to_cls:
+            raise ValueError(f"Unknown distribution type: {type_}")
+
+        if len(parameters) != 2:
+            raise ValueError(
+                f"Expected two parameters, got {len(parameters)}: {parameters}"
+            )
+
+        if bounds is not None and len(bounds) != 2:
+            raise ValueError(
+                f"Expected two bounds, got {len(bounds)}: {bounds}"
+            )
+
+        self.type = type_
+        self.parameters = parameters
+        self.bounds = bounds
+        self.transformation = transformation
+        self.parameter_scale = parameter_scale
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"{self.parameters[0]!r}, {self.parameters[1]!r},"
+            f" bounds={self.bounds!r}, transformation={self.transformation!r}"
+            ")"
+        )
+
+    @abc.abstractmethod
+    def sample(self, shape=None) -> np.ndarray:
+        """Sample from the distribution.
+
+        :param shape: The shape of the sample.
+        :return: A sample from the distribution.
+        """
+        ...
+
+    def _scale_sample(self, sample):
+        """Scale the sample to the parameter space"""
+        if self.parameter_scale:
+            return sample
+
+        return scale(sample, self.transformation)
+
+    def _clip_to_bounds(self, x):
+        """Clip `x` values to bounds.
+
+        :param x: The values to clip. Assumed to be on the parameter scale.
+        """
+        # TODO: replace this by proper truncation
+        if self.bounds is None:
+            return x
+
+        return np.maximum(
+            np.minimum(self.ub_scaled, x),
+            self.lb_scaled,
+        )
+
+    @property
+    def lb_scaled(self):
+        """The lower bound on the parameter scale."""
+        return scale(self.bounds[0], self.transformation)
+
+    @property
+    def ub_scaled(self):
+        """The upper bound on the parameter scale."""
+        return scale(self.bounds[1], self.transformation)
+
+    @abc.abstractmethod
+    def _pdf(self, x):
+        """Probability density function at x.
+
+        :param x: The value at which to evaluate the PDF.
+            ``x`` is assumed to be on the linear scale.
+        :return: The value of the PDF at ``x``.
+        """
+        ...
+
+    def pdf(self, x):
+        """Probability density function at x.
+
+        :param x: The value at which to evaluate the PDF.
+            ``x`` is assumed to be on the parameter scale.
+        :return: The value of the PDF at ``x``. Note that the PDF does
+            currently not account for the clipping at the bounds.
+        """
+        x = x if self.parameter_scale else unscale(x, self.transformation)
+
+        # scale the PDF to the parameter scale
+        if self.parameter_scale or self.transformation == C.LIN:
+            coeff = 1
+        elif self.transformation == C.LOG10:
+            coeff = x * np.log(10)
+        elif self.transformation == C.LOG:
+            coeff = x
+        else:
+            raise ValueError(f"Unknown transformation: {self.transformation}")
+
+        return self._pdf(x) * coeff
+
+    def neglogprior(self, x):
+        """Negative log-prior at x.
+
+        :param x: The value at which to evaluate the negative log-prior.
+            ``x`` is assumed to be on the parameter scale.
+        :return: The negative log-prior at ``x``.
+        """
+        return -np.log(self.pdf(x))
+
+    @staticmethod
+    def from_par_dict(
+        d, type_=Literal["initialization", "objective"]
+    ) -> Distribution:
+        """Create a distribution from a row of the parameter table.
+
+        :param d: A dictionary representing a row of the parameter table.
+        :param type_: The type of the distribution.
+        :return: A distribution object.
+        """
+        dist_type = d.get(f"{type_}PriorType", C.NORMAL)
+        if not isinstance(dist_type, str) and np.isnan(dist_type):
+            dist_type = C.PARAMETER_SCALE_UNIFORM
+        cls = Distribution._type_to_cls[dist_type]
+
+        pscale = d.get(C.PARAMETER_SCALE, C.LIN)
+        if (
+            pd.isna(d[f"{type_}PriorParameters"])
+            and dist_type == C.PARAMETER_SCALE_UNIFORM
+        ):
+            params = (
+                scale(d[C.LOWER_BOUND], pscale),
+                scale(d[C.UPPER_BOUND], pscale),
+            )
+        else:
+            params = tuple(
+                map(
+                    float,
+                    d[f"{type_}PriorParameters"].split(C.PARAMETER_SEPARATOR),
+                )
+            )
+        return cls(
+            *params,
+            bounds=(d[C.LOWER_BOUND], d[C.UPPER_BOUND]),
+            transformation=pscale,
+        )
+
+
+class Normal(Distribution):
+    """A normal distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.NORMAL,
+            transformation=transformation,
+            parameters=(mean, std),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.normal(
+            loc=self.parameters[0], scale=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return norm.pdf(x, loc=self.parameters[0], scale=self.parameters[1])
+
+
+class LogNormal(Distribution):
+    """A log-normal distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.LOG_NORMAL,
+            transformation=transformation,
+            parameters=(mean, std),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.lognormal(
+            mean=self.parameters[0], sigma=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return lognorm.pdf(
+            x, scale=np.exp(self.parameters[0]), s=self.parameters[1]
+        )
+
+
+class Uniform(Distribution):
+    """A uniform distribution."""
+
+    def __init__(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.UNIFORM,
+            transformation=transformation,
+            parameters=(lower_bound, upper_bound),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.uniform(
+            low=self.parameters[0], high=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return uniform.pdf(
+            x,
+            loc=self.parameters[0],
+            scale=self.parameters[1] - self.parameters[0],
+        )
+
+
+class Laplace(Distribution):
+    """A Laplace distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        scale: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.LAPLACE,
+            transformation=transformation,
+            parameters=(mean, scale),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    def sample(self, shape=None):
+        sample = np.random.laplace(
+            loc=self.parameters[0], scale=self.parameters[1], size=shape
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return laplace.pdf(x, loc=self.parameters[0], scale=self.parameters[1])
+
+
+class LogLaplace(Distribution):
+    """A log-Laplace distribution."""
+
+    def __init__(
+        self,
+        mean: float,
+        scale: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.LOG_LAPLACE,
+            transformation=transformation,
+            parameters=(mean, scale),
+            bounds=bounds,
+            parameter_scale=False,
+        )
+
+    @property
+    def mean(self):
+        """The mean of the underlying Laplace distribution."""
+        return self.parameters[0]
+
+    @property
+    def scale(self):
+        """The scale of the underlying Laplace distribution."""
+        return self.parameters[1]
+
+    def sample(self, shape=None):
+        sample = np.exp(
+            np.random.laplace(loc=self.mean, scale=self.scale, size=shape)
+        )
+        return self._clip_to_bounds(self._scale_sample(sample))
+
+    def _pdf(self, x):
+        return (
+            1
+            / (2 * self.scale * x)
+            * np.exp(-np.abs(np.log(x) - self.mean) / self.scale)
+        )
+
+
+class ParameterScaleNormal(Distribution):
+    """A normal distribution with parameters on the parameter scale."""
+
+    def __init__(
+        self,
+        mean: float,
+        std: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.PARAMETER_SCALE_NORMAL,
+            transformation=transformation,
+            parameters=(mean, std),
+            bounds=bounds,
+            parameter_scale=True,
+        )
+
+    sample = Normal.sample
+    _pdf = Normal._pdf
+
+
+class ParameterScaleUniform(Distribution):
+    """A uniform distribution with parameters on the parameter scale."""
+
+    def __init__(
+        self,
+        lower_bound: float,
+        upper_bound: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.PARAMETER_SCALE_UNIFORM,
+            transformation=transformation,
+            parameters=(lower_bound, upper_bound),
+            bounds=bounds,
+            parameter_scale=True,
+        )
+
+    sample = Uniform.sample
+    _pdf = Uniform._pdf
+
+
+class ParameterScaleLaplace(Distribution):
+    """A Laplace distribution with parameters on the parameter scale."""
+
+    def __init__(
+        self,
+        mean: float,
+        scale: float,
+        bounds: tuple = None,
+        transformation: str = C.LIN,
+    ):
+        super().__init__(
+            C.PARAMETER_SCALE_LAPLACE,
+            transformation=transformation,
+            parameters=(mean, scale),
+            bounds=bounds,
+            parameter_scale=True,
+        )
+
+    sample = Laplace.sample
+    _pdf = Laplace._pdf
+
+
+Distribution._type_to_cls = {
+    C.NORMAL: Normal,
+    C.LOG_NORMAL: LogNormal,
+    C.UNIFORM: Uniform,
+    C.LAPLACE: Laplace,
+    C.LOG_LAPLACE: LogLaplace,
+    C.PARAMETER_SCALE_NORMAL: ParameterScaleNormal,
+    C.PARAMETER_SCALE_UNIFORM: ParameterScaleUniform,
+    C.PARAMETER_SCALE_LAPLACE: ParameterScaleLaplace,
+}

--- a/petab/v1/sampling.py
+++ b/petab/v1/sampling.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 import numpy as np
 import pandas as pd
 
-from . import parameters
 from .C import *  # noqa: F403
+from .distributions import Distribution
 
 __all__ = ["sample_from_prior", "sample_parameter_startpoints"]
 
@@ -26,84 +26,10 @@ def sample_from_prior(
     """
     # unpack info
     p_type, p_params, scaling, bounds = prior
+    prior_cls = Distribution._type_to_cls[p_type]
+    prior = prior_cls(*p_params, bounds=tuple(bounds), transformation=scaling)
 
-    # define a function to rescale the sampled points to parameter scale
-    def scale(x):
-        if scaling == LIN:
-            return x
-        if scaling == LOG:
-            return np.log(x)
-        if scaling == LOG10:
-            return np.log10(x)
-        raise NotImplementedError(
-            f"Parameter priors on the parameter scale {scaling} are "
-            "currently not implemented."
-        )
-
-    def clip_to_bounds(x: np.array):
-        """Clip values in array x to bounds"""
-        return np.maximum(np.minimum(scale(bounds[1]), x), scale(bounds[0]))
-
-    # define lambda functions for each parameter
-    if p_type == UNIFORM:
-        sp = scale(
-            (p_params[1] - p_params[0]) * np.random.random((n_starts,))
-            + p_params[0]
-        )
-
-    elif p_type == PARAMETER_SCALE_UNIFORM:
-        sp = (p_params[1] - p_params[0]) * np.random.random(
-            (n_starts,)
-        ) + p_params[0]
-
-    elif p_type == NORMAL:
-        sp = scale(
-            np.random.normal(
-                loc=p_params[0], scale=p_params[1], size=(n_starts,)
-            )
-        )
-
-    elif p_type == LOG_NORMAL:
-        sp = scale(
-            np.exp(
-                np.random.normal(
-                    loc=p_params[0], scale=p_params[1], size=(n_starts,)
-                )
-            )
-        )
-
-    elif p_type == PARAMETER_SCALE_NORMAL:
-        sp = np.random.normal(
-            loc=p_params[0], scale=p_params[1], size=(n_starts,)
-        )
-
-    elif p_type == LAPLACE:
-        sp = scale(
-            np.random.laplace(
-                loc=p_params[0], scale=p_params[1], size=(n_starts,)
-            )
-        )
-
-    elif p_type == LOG_LAPLACE:
-        sp = scale(
-            np.exp(
-                np.random.laplace(
-                    loc=p_params[0], scale=p_params[1], size=(n_starts,)
-                )
-            )
-        )
-
-    elif p_type == PARAMETER_SCALE_LAPLACE:
-        sp = np.random.laplace(
-            loc=p_params[0], scale=p_params[1], size=(n_starts,)
-        )
-
-    else:
-        raise NotImplementedError(
-            f"Parameter priors of type {prior[0]} are not implemented."
-        )
-
-    return clip_to_bounds(sp)
+    return prior.sample(shape=(n_starts,))
 
 
 def sample_parameter_startpoints(
@@ -130,11 +56,24 @@ def sample_parameter_startpoints(
     if seed is not None:
         np.random.seed(seed)
 
+    par_to_estimate = parameter_df.loc[parameter_df[ESTIMATE] == 1]
+
+    if parameter_ids is not None:
+        try:
+            par_to_estimate = par_to_estimate.loc[parameter_ids, :]
+        except KeyError as e:
+            missing_ids = set(parameter_ids) - set(par_to_estimate.index)
+            raise KeyError(
+                "Parameter table does not contain estimated parameter(s) "
+                f"{missing_ids}."
+            ) from e
+
     # get types and parameters of priors from dataframe
-    prior_list = parameters.get_priors_from_df(
-        parameter_df, mode=INITIALIZATION, parameter_ids=parameter_ids
-    )
-
-    startpoints = [sample_from_prior(prior, n_starts) for prior in prior_list]
-
-    return np.array(startpoints).T
+    return np.array(
+        [
+            Distribution.from_par_dict(row, type_="initialization").sample(
+                n_starts
+            )
+            for row in par_to_estimate.to_dict("records")
+        ]
+    ).T

--- a/tests/v1/test_distributions.py
+++ b/tests/v1/test_distributions.py
@@ -1,0 +1,43 @@
+from itertools import product
+
+import numpy as np
+import pytest
+from scipy.integrate import cumulative_trapezoid
+from scipy.stats import kstest
+
+from petab.v1.distributions import *
+from petab.v2.C import *
+
+
+@pytest.mark.parametrize(
+    "distribution, transform",
+    list(
+        product(
+            [
+                Normal(1, 1),
+                LogNormal(2, 1),
+                Uniform(2, 4),
+                Laplace(1, 2),
+                LogLaplace(1, 0.5),
+                ParameterScaleNormal(1, 1),
+                ParameterScaleLaplace(1, 2),
+                ParameterScaleUniform(1, 2),
+            ],
+            [LIN, LOG, LOG10],
+        )
+    ),
+)
+def test_sample_matches_pdf(distribution, transform):
+    """Test that the sample matches the PDF."""
+    np.random.seed(1)
+    N_SAMPLES = 10000
+    distribution.transform = transform
+    sample = distribution.sample(N_SAMPLES)
+
+    # pdf -> cdf
+    def cdf(x):
+        return cumulative_trapezoid(distribution.pdf(x), x)
+
+    # Kolmogorov-Smirnov test to check if the sample is drawn from the CDF
+    _, p = kstest(sample, cdf)
+    assert p > 0.05, (p, distribution)

--- a/tests/v1/test_priors.py
+++ b/tests/v1/test_priors.py
@@ -5,10 +5,17 @@ import benchmark_models_petab
 import numpy as np
 import pandas as pd
 import pytest
-from scipy.stats import norm
 
 import petab.v1
-from petab.v1 import get_simulation_conditions
+from petab.v1 import (
+    ESTIMATE,
+    MEASUREMENT,
+    OBSERVABLE_ID,
+    SIMULATION,
+    get_simulation_conditions,
+    get_simulation_df,
+)
+from petab.v1.distributions import Distribution
 from petab.v1.priors import priors_to_measurements
 
 
@@ -17,6 +24,7 @@ from petab.v1.priors import priors_to_measurements
 )
 def test_priors_to_measurements(problem_id):
     """Test the conversion of priors to measurements."""
+    # setup
     petab_problem_priors: petab.v1.Problem = (
         benchmark_models_petab.get_problem(problem_id)
     )
@@ -29,8 +37,17 @@ def test_priors_to_measurements(problem_id):
             petab_problem_priors
         )
         assert petab.v1.lint_problem(petab_problem_priors) is False
-    original_problem = deepcopy(petab_problem_priors)
 
+    original_problem = deepcopy(petab_problem_priors)
+    x_scaled_dict = dict(
+        zip(
+            original_problem.x_free_ids,
+            original_problem.x_nominal_free_scaled,
+            strict=True,
+        )
+    )
+
+    # convert priors to measurements
     petab_problem_measurements = priors_to_measurements(petab_problem_priors)
 
     # check that the original problem is not modified
@@ -45,6 +62,7 @@ def test_priors_to_measurements(problem_id):
                 getattr(original_problem, attr)
             )
         ).empty, diff
+
     # check that measurements and observables were added
     assert petab.v1.lint_problem(petab_problem_measurements) is False
     assert (
@@ -59,6 +77,7 @@ def test_priors_to_measurements(problem_id):
         petab_problem_measurements.measurement_df.shape[0]
         > petab_problem_priors.measurement_df.shape[0]
     )
+
     # ensure we didn't introduce any new conditions
     assert len(
         get_simulation_conditions(petab_problem_measurements.measurement_df)
@@ -67,24 +86,38 @@ def test_priors_to_measurements(problem_id):
     # verify that the objective function value is the same
 
     # load/construct the simulation results
-    simulation_df_priors = petab.v1.get_simulation_df(
+    simulation_df_priors = get_simulation_df(
         Path(
             benchmark_models_petab.MODELS_DIR,
             problem_id,
             f"simulatedData_{problem_id}.tsv",
         )
     )
-    simulation_df_measurements = pd.concat(
-        [
-            petab_problem_measurements.measurement_df.rename(
-                columns={petab.v1.MEASUREMENT: petab.v1.SIMULATION}
-            )[
-                petab_problem_measurements.measurement_df[
-                    petab.v1.C.OBSERVABLE_ID
-                ].str.startswith("prior_")
-            ],
-            simulation_df_priors,
+    # for the prior observables, we need to "simulate" the model with the
+    #  nominal parameter values
+    simulated_prior_observables = (
+        petab_problem_measurements.measurement_df.rename(
+            columns={MEASUREMENT: SIMULATION}
+        )[
+            petab_problem_measurements.measurement_df[
+                OBSERVABLE_ID
+            ].str.startswith("prior_")
         ]
+    )
+
+    def apply_parameter_values(row):
+        # apply the parameter values to the observable formula for the prior
+        if row[OBSERVABLE_ID].startswith("prior_"):
+            row[SIMULATION] = x_scaled_dict[
+                row[OBSERVABLE_ID].removeprefix("prior_")
+            ]
+        return row
+
+    simulated_prior_observables = simulated_prior_observables.apply(
+        apply_parameter_values, axis=1
+    )
+    simulation_df_measurements = pd.concat(
+        [simulation_df_priors, simulated_prior_observables]
     )
 
     llh_priors = petab.v1.calculate_llh_for_table(
@@ -102,36 +135,23 @@ def test_priors_to_measurements(problem_id):
 
     # get prior objective function contribution
     parameter_ids = petab_problem_priors.parameter_df.index.values[
-        (petab_problem_priors.parameter_df[petab.v1.ESTIMATE] == 1)
+        (petab_problem_priors.parameter_df[ESTIMATE] == 1)
         & petab_problem_priors.parameter_df[
             petab.v1.OBJECTIVE_PRIOR_TYPE
         ].notna()
     ]
-    priors = petab.v1.get_priors_from_df(
-        petab_problem_priors.parameter_df,
-        mode="objective",
-        parameter_ids=parameter_ids,
-    )
+    priors = [
+        Distribution.from_par_dict(
+            petab_problem_priors.parameter_df.loc[par_id], type_="objective"
+        )
+        for par_id in parameter_ids
+    ]
     prior_contrib = 0
     for parameter_id, prior in zip(parameter_ids, priors, strict=True):
-        prior_type, prior_pars, par_scale, par_bounds = prior
-        if prior_type == petab.v1.PARAMETER_SCALE_NORMAL:
-            prior_contrib += norm.logpdf(
-                petab_problem_priors.x_nominal_free_scaled[
-                    petab_problem_priors.x_free_ids.index(parameter_id)
-                ],
-                loc=prior_pars[0],
-                scale=prior_pars[1],
-            )
-        else:
-            # enable other models, once libpetab has proper support for
-            #  evaluating the prior contribution. until then, two test
-            #  problems should suffice
-            assert problem_id == "Raimundez_PCB2020"
-            pytest.skip(f"Prior type {prior_type} not implemented")
+        prior_contrib -= prior.neglogprior(x_scaled_dict[parameter_id])
 
     assert np.isclose(
-        llh_priors + prior_contrib, llh_measurements, rtol=1e-3, atol=1e-16
+        llh_priors + prior_contrib, llh_measurements, rtol=1e-8, atol=1e-16
     ), (llh_priors + prior_contrib, llh_measurements)
     # check that the tolerance is not too high
     assert np.abs(prior_contrib) > 1e-3 * np.abs(llh_priors)


### PR DESCRIPTION
**requires #329**

Currently, when sampled startpoints are outside the bounds, their value is set to the upper/lower bounds. This may put too much probability mass on the bounds.

With these changes, we properly sample from the respective truncated distributions.

Closes #330.