### PR TITLE
Fix `get_required_parameters_for_parameter_table`

### DIFF
--- a/petab/v1/parameters.py
+++ b/petab/v1/parameters.py
@@ -332,9 +332,8 @@ def get_required_parameters_for_parameter_table(
         if not model.has_entity_with_id(p):
             parameter_ids[p] = None
 
-    # remove parameters that occur in the condition table and are overridden
-    #  for ALL conditions
-    for p in condition_df.columns[~condition_df.isnull().any()]:
+    # parameters that are overridden via the condition table are not allowed
+    for p in condition_df.columns:
         try:
             del parameter_ids[p]
         except KeyError:

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -621,11 +621,8 @@ def get_required_parameters_for_parameter_table(
         if not problem.model.has_entity_with_id(p)
     )
 
-    # remove parameters that occur in the condition table and are overridden
-    #  for ALL conditions
-    for p in problem.condition_df.columns[
-        ~problem.condition_df.isnull().any()
-    ]:
+    # parameters that are overridden via the condition table are not allowed
+    for p in problem.condition_df.columns:
         try:
             parameter_ids.remove(p)
         except KeyError:

--- a/petab/v2/problem.py
+++ b/petab/v2/problem.py
@@ -32,7 +32,7 @@ from ..v2.C import *  # noqa: F403
 from . import experiments
 
 if TYPE_CHECKING:
-    from ..v2.lint import ValidationIssue, ValidationResultList, ValidationTask
+    from ..v2.lint import ValidationResultList, ValidationTask
 
 
 __all__ = ["Problem"]
@@ -722,7 +722,11 @@ class Problem:
         Returns:
             A list of validation results.
         """
-        from ..v2.lint import ValidationIssueSeverity, ValidationResultList
+        from ..v2.lint import (
+            ValidationIssue,
+            ValidationIssueSeverity,
+            ValidationResultList,
+        )
 
         validation_results = ValidationResultList()
         if self.extensions_config:


### PR DESCRIPTION
The previous check did not make any sense. See discussion at https://github.com/PEtab-dev/libpetab-python/pull/339#discussion_r1878856556.

Also fix a missing import.