### PR TITLE
Fix petablint v2 warning

### DIFF
--- a/petab/petablint.py
+++ b/petab/petablint.py
@@ -12,9 +12,8 @@ from jsonschema.exceptions import ValidationError as SchemaValidationError
 
 import petab.v1 as petab
 from petab.v1.C import FORMAT_VERSION
-from petab.v2.lint import lint_problem
+from petab.v1.yaml import validate
 from petab.versions import get_major_version
-from petab.yaml import validate
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +177,8 @@ def main():
                 ret = petab.lint.lint_problem(problem)
                 sys.exit(ret)
             case 2:
+                from petab.v2.lint import lint_problem
+
                 validation_issues = lint_problem(args.yaml_file_name)
                 if validation_issues:
                     validation_issues.log(logger=logger)

--- a/petab/versions.py
+++ b/petab/versions.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import petab
 from petab.v1 import Problem as V1Problem
 from petab.v1.C import FORMAT_VERSION
 from petab.v1.yaml import load_yaml
-from petab.v2 import Problem as V2Problem
 
 __all__ = [
     "get_major_version",
@@ -14,22 +14,27 @@ __all__ = [
 
 
 def get_major_version(
-    problem: str | dict | Path | V1Problem | V2Problem,
+    problem: str | dict | Path | V1Problem | petab.v2.Problem,
 ) -> int:
     """Get the major version number of the given problem."""
-    if isinstance(problem, V1Problem):
-        return 1
-
-    if isinstance(problem, V2Problem):
-        return 2
+    version = None
 
     if isinstance(problem, str | Path):
         yaml_config = load_yaml(problem)
         version = yaml_config.get(FORMAT_VERSION)
     elif isinstance(problem, dict):
         version = problem.get(FORMAT_VERSION)
-    else:
-        raise ValueError(f"Unsupported argument type: {type(problem)}")
 
-    version = str(version)
-    return int(version.split(".")[0])
+    if version is not None:
+        version = str(version)
+        return int(version.split(".")[0])
+
+    if isinstance(problem, V1Problem):
+        return 1
+
+    from . import v2
+
+    if isinstance(problem, v2.Problem):
+        return 2
+
+    raise ValueError(f"Unsupported argument type: {type(problem)}")


### PR DESCRIPTION
Don't show `Support for PEtab2.0 and all of petab.v2 is experimental` warning when validating PEtab v1 problems.

Import `petab.v2.*`  only when needed.