### PR TITLE
Fix v2 import Deprecation warning

### DIFF
--- a/petab/__init__.py
+++ b/petab/__init__.py
@@ -23,6 +23,8 @@ def __getattr__(name):
         return attr
     if name == "v1":
         return importlib.import_module("petab.v1")
+    if name == "v2":
+        return importlib.import_module("petab.v2")
     if name != "__path__":
         warn(
             f"Accessing `petab.{name}` is deprecated and will be removed in "


### PR DESCRIPTION
Fixes this nonsensical warning:

> E   DeprecationWarning: Accessing `petab.v2` is deprecated and will be removed in the next major release. Please use `petab.v1.v2` instead.