### PR TITLE
Add petab-compatible sympy string-printer

### DIFF
--- a/petab/v1/math/__init__.py
+++ b/petab/v1/math/__init__.py
@@ -1,3 +1,4 @@
 """Functions for parsing and evaluating mathematical expressions."""
 
+from .printer import PetabStrPrinter, petab_math_str  # noqa: F401
 from .sympify import sympify_petab  # noqa: F401

--- a/petab/v1/math/printer.py
+++ b/petab/v1/math/printer.py
@@ -1,0 +1,91 @@
+"""A PEtab-compatible sympy string-printer."""
+
+from itertools import chain, islice
+
+import sympy as sp
+from sympy.printing.str import StrPrinter
+
+
+class PetabStrPrinter(StrPrinter):
+    """A PEtab-compatible sympy string-printer."""
+
+    #: Mapping of sympy functions to PEtab functions
+    _func_map = {
+        "asin": "arcsin",
+        "acos": "arccos",
+        "atan": "arctan",
+        "acot": "arccot",
+        "asec": "arcsec",
+        "acsc": "arccsc",
+        "asinh": "arcsinh",
+        "acosh": "arccosh",
+        "atanh": "arctanh",
+        "acoth": "arccoth",
+        "asech": "arcsech",
+        "acsch": "arccsch",
+        "Abs": "abs",
+    }
+
+    def _print_BooleanTrue(self, expr):
+        return "true"
+
+    def _print_BooleanFalse(self, expr):
+        return "false"
+
+    def _print_Pow(self, expr: sp.Pow):
+        """Custom printing for the power operator"""
+        base, exp = expr.as_base_exp()
+        return f"{self._print(base)} ^ {self._print(exp)}"
+
+    def _print_Infinity(self, expr):
+        """Custom printing for infinity"""
+        return "inf"
+
+    def _print_NegativeInfinity(self, expr):
+        """Custom printing for negative infinity"""
+        return "-inf"
+
+    def _print_Function(self, expr):
+        """Custom printing for specific functions"""
+
+        if expr.func.__name__ == "Piecewise":
+            return self._print_Piecewise(expr)
+
+        if func := self._func_map.get(expr.func.__name__):
+            return f"{func}({', '.join(map(self._print, expr.args))})"
+
+        return super()._print_Function(expr)
+
+    def _print_Piecewise(self, expr):
+        """Custom printing for Piecewise function"""
+        # merge the tuples and drop the final `True` condition
+        str_args = map(
+            self._print,
+            islice(chain.from_iterable(expr.args), 2 * len(expr.args) - 1),
+        )
+        return f"piecewise({', '.join(str_args)})"
+
+    def _print_Min(self, expr):
+        """Custom printing for Min function"""
+        return f"min({', '.join(map(self._print, expr.args))})"
+
+    def _print_Max(self, expr):
+        """Custom printing for Max function"""
+        return f"max({', '.join(map(self._print, expr.args))})"
+
+
+def petab_math_str(expr: sp.Basic | sp.Expr | None) -> str:
+    """Convert a sympy expression to a PEtab-compatible math expression string.
+
+    :example:
+    >>> expr = sp.sympify("x**2 + sin(y)")
+    >>> petab_math_str(expr)
+    'x ^ 2 + sin(y)'
+    >>> expr = sp.sympify("Piecewise((1, x > 0), (0, True))")
+    >>> petab_math_str(expr)
+    'piecewise(1, x > 0, 0)'
+    """
+    if expr is None:
+        return ""
+
+    return PetabStrPrinter().doprint(expr)

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -25,7 +25,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from ..v1.lint import is_valid_identifier
-from ..v1.math import sympify_petab
+from ..v1.math import petab_math_str, sympify_petab
 from . import C, get_observable_df
 
 __all__ = [
@@ -273,23 +273,8 @@ class ObservableTable(BaseModel):
         for record in records:
             obs = record[C.OBSERVABLE_FORMULA]
             noise = record[C.NOISE_FORMULA]
-            record[C.OBSERVABLE_FORMULA] = (
-                None
-                if obs is None
-                # TODO: we need a custom printer for sympy expressions
-                #  to avoid '**'
-                #  https://github.com/PEtab-dev/libpetab-python/issues/362
-                else str(obs)
-                if not obs.is_number
-                else float(obs)
-            )
-            record[C.NOISE_FORMULA] = (
-                None
-                if noise is None
-                else str(noise)
-                if not noise.is_number
-                else float(noise)
-            )
+            record[C.OBSERVABLE_FORMULA] = petab_math_str(obs)
+            record[C.NOISE_FORMULA] = petab_math_str(noise)
         return pd.DataFrame(records).set_index([C.OBSERVABLE_ID])
 
     @classmethod

--- a/tests/v1/math/test_math.py
+++ b/tests/v1/math/test_math.py
@@ -6,9 +6,9 @@ import pytest
 import sympy as sp
 import yaml
 from sympy.abc import _clash
-from sympy.logic.boolalg import Boolean
+from sympy.logic.boolalg import Boolean, BooleanFalse, BooleanTrue
 
-from petab.math import sympify_petab
+from petab.v1.math import petab_math_str, sympify_petab
 
 
 def test_sympify_numpy():
@@ -27,6 +27,20 @@ def test_parse_simple():
 def test_evaluate():
     act = sympify_petab("piecewise(1, 1 > 2, 0)", evaluate=False)
     assert str(act) == "Piecewise((1.0, 1.0 > 2.0), (0.0, True))"
+
+
+def test_assumptions():
+    # in PEtab, all symbols are expected to be real-valued
+    assert sympify_petab("x").is_real
+
+    # non-real symbols are changed to real
+    assert sympify_petab(sp.Symbol("x", real=False)).is_real
+
+
+def test_printer():
+    assert petab_math_str(None) == ""
+    assert petab_math_str(BooleanTrue()) == "true"
+    assert petab_math_str(BooleanFalse()) == "false"
 
 
 def read_cases():
@@ -60,19 +74,26 @@ def read_cases():
 @pytest.mark.parametrize("expr_str, expected", read_cases())
 def test_parse_cases(expr_str, expected):
     """Test PEtab math expressions for the PEtab test suite."""
-    result = sympify_petab(expr_str)
-    if isinstance(result, Boolean):
-        assert result == expected
+    sym_expr = sympify_petab(expr_str)
+    if isinstance(sym_expr, Boolean):
+        assert sym_expr == expected
     else:
         try:
-            result = float(result.evalf())
+            result = float(sym_expr.evalf())
             assert np.isclose(result, expected), (
                 f"{expr_str}: Expected {expected}, got {result}"
             )
         except TypeError:
-            assert result == expected, (
+            assert sym_expr == expected, (
                 f"{expr_str}: Expected {expected}, got {result}"
             )
+
+    # test parsing, printing, and parsing again
+    resympified = sympify_petab(petab_math_str(sym_expr))
+    if sym_expr.is_number:
+        assert np.isclose(float(resympified), float(sym_expr))
+    else:
+        assert resympified.equals(sym_expr), (sym_expr, resympified)
 
 
 def test_ids():
@@ -80,9 +101,8 @@ def test_ids():
     assert sympify_petab("bla * 2") == 2.0 * sp.Symbol("bla", real=True)
 
     # test that sympy expressions that are invalid in PEtab raise an error
-    # TODO: handle these cases after
-    #   https://github.com/PEtab-dev/libpetab-python/pull/364
-    # sympify_petab(sp.Symbol("föö"))
+    with pytest.raises(ValueError):
+        sympify_petab(sp.Symbol("föö"))
 
 
 def test_syntax_error():

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -133,7 +133,9 @@ def test_modify_problem():
         }
     ).set_index([OBSERVABLE_ID])
     assert_frame_equal(
-        problem.observable_df[[OBSERVABLE_FORMULA, NOISE_FORMULA]],
+        problem.observable_df[[OBSERVABLE_FORMULA, NOISE_FORMULA]].map(
+            lambda x: float(x) if x != "" else None
+        ),
         exp_observable_df,
         check_dtype=False,
     )


### PR DESCRIPTION
Add a sympy Printer to stringify sympy expressions in a petab-compatible way. For example, we need to avoid `str(sympy.sympify("x^2"))` -> `'x**2'`.

Closes #362.