### PR TITLE
lint: Don't fail on missing noiseFormula

### DIFF
--- a/petab/v1/lint.py
+++ b/petab/v1/lint.py
@@ -906,21 +906,6 @@ def lint_problem(problem: "petab.Problem") -> bool:
     else:
         logger.warning("Model not available. Skipping.")
 
-    if problem.measurement_df is not None:
-        logger.info("Checking measurement table...")
-        try:
-            check_measurement_df(problem.measurement_df, problem.observable_df)
-
-            if problem.condition_df is not None:
-                assert_measurement_conditions_present_in_condition_table(
-                    problem.measurement_df, problem.condition_df
-                )
-        except AssertionError as e:
-            logger.error(e)
-            errors_occurred = True
-    else:
-        logger.warning("Measurement table not available. Skipping.")
-
     if problem.condition_df is not None:
         logger.info("Checking condition table...")
         try:
@@ -952,6 +937,21 @@ def lint_problem(problem: "petab.Problem") -> bool:
                     errors_occurred = True
     else:
         logger.warning("Observable table not available. Skipping.")
+
+    if problem.measurement_df is not None:
+        logger.info("Checking measurement table...")
+        try:
+            check_measurement_df(problem.measurement_df, problem.observable_df)
+
+            if problem.condition_df is not None:
+                assert_measurement_conditions_present_in_condition_table(
+                    problem.measurement_df, problem.condition_df
+                )
+        except AssertionError as e:
+            logger.error(e)
+            errors_occurred = True
+    else:
+        logger.warning("Measurement table not available. Skipping.")
 
     if problem.parameter_df is not None:
         logger.info("Checking parameter table...")

--- a/petab/v1/measurements.py
+++ b/petab/v1/measurements.py
@@ -277,16 +277,20 @@ def assert_overrides_match_parameter_count(
             strict=True,
         )
     }
-    noise_parameters_count = {
-        obs_id: len(
-            observables.get_formula_placeholders(formula, obs_id, "noise")
-        )
-        for obs_id, formula in zip(
-            observable_df.index.values,
-            observable_df[NOISE_FORMULA],
-            strict=True,
-        )
-    }
+    noise_parameters_count = (
+        {
+            obs_id: len(
+                observables.get_formula_placeholders(formula, obs_id, "noise")
+            )
+            for obs_id, formula in zip(
+                observable_df.index.values,
+                observable_df[NOISE_FORMULA],
+                strict=True,
+            )
+        }
+        if NOISE_FORMULA in observable_df.columns
+        else {obs_id: 0 for obs_id in observable_df.index.values}
+    )
 
     for _, row in measurement_df.iterrows():
         # check observable parameters


### PR DESCRIPTION
Handle missing `noiseFormula` in `assert_overrides_match_parameter_count`.

Fixes #219.

