### PR TITLE
Allow empty string "" in columns to be overridden with default values in priors

### DIFF
--- a/petab/v1/priors.py
+++ b/petab/v1/priors.py
@@ -278,7 +278,10 @@ class Prior:
         :return: A distribution object.
         """
         dist_type = d.get(f"{type_}PriorType", C.PARAMETER_SCALE_UNIFORM)
-        if not isinstance(dist_type, str) and np.isnan(dist_type):
+        if (
+            (not isinstance(dist_type, str) and np.isnan(dist_type))
+            or not dist_type
+        ):
             dist_type = C.PARAMETER_SCALE_UNIFORM
 
         pscale = d.get(C.PARAMETER_SCALE, C.LIN)

--- a/petab/v1/priors.py
+++ b/petab/v1/priors.py
@@ -277,12 +277,11 @@ class Prior:
             at the bounds. **deprecated**.
         :return: A distribution object.
         """
-        dist_type = d.get(f"{type_}PriorType", C.PARAMETER_SCALE_UNIFORM)
-        if (
-            (not isinstance(dist_type, str) and np.isnan(dist_type))
-            or not dist_type
+        dist_type = C.PARAMETER_SCALE_UNIFORM
+        if (_table_dist_type := d.get(f"{type_}PriorType")) and (
+            isinstance(_table_dist_type, str) or not np.isnan(_table_dist_type)
         ):
-            dist_type = C.PARAMETER_SCALE_UNIFORM
+            dist_type = _table_dist_type
 
         pscale = d.get(C.PARAMETER_SCALE, C.LIN)
         params = d.get(f"{type_}PriorParameters", None)


### PR DESCRIPTION
The check only looked for whether it was not a string, but empty string values that are passed as `""` were not caught here. This should fix the error.