### PR TITLE
Fix parameter scale in sample_from_prior

### DIFF
--- a/petab/v1/sampling.py
+++ b/petab/v1/sampling.py
@@ -33,7 +33,7 @@ def sample_from_prior(
         bounds=tuple(bounds),
         transformation=scaling,
     )
-    return prior.sample(shape=(n_starts,))
+    return prior.sample(shape=(n_starts,), x_scaled=True)
 
 
 def sample_parameter_startpoints(


### PR DESCRIPTION
Return sampled parameters on the parameter scale.
This broke in #329 & #335.
