### PR TITLE
v2: Update to new observable placeholder specification

### DIFF
--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -145,10 +145,14 @@ EXPERIMENT_DF_REQUIRED_COLS = [
 OBSERVABLE_NAME = "observableName"
 #: Observable formula column in the observable table
 OBSERVABLE_FORMULA = "observableFormula"
+#: Observable placeholders column in the observable table
+OBSERVABLE_PLACEHOLDERS = "observablePlaceholders"
 #: Noise formula column in the observable table
 NOISE_FORMULA = "noiseFormula"
 #: Noise distribution column in the observable table
 NOISE_DISTRIBUTION = "noiseDistribution"
+#: Noise placeholders column in the observable table
+NOISE_PLACEHOLDERS = "noisePlaceholders"
 
 #: Mandatory columns of observable table
 OBSERVABLE_DF_REQUIRED_COLS = [

--- a/tests/v2/test_core.py
+++ b/tests/v2/test_core.py
@@ -160,28 +160,22 @@ def test_observable():
     assert Observable(id="obs1", formula="x + y", non_petab=1).non_petab == 1
 
     o = Observable(id="obs1", formula=x + y)
-    assert o.observable_placeholders == set()
-    assert o.noise_placeholders == set()
+    assert o.observable_placeholders == []
+    assert o.noise_placeholders == []
 
     o = Observable(
         id="obs1",
         formula="observableParameter1_obs1",
         noise_formula="noiseParameter1_obs1",
+        observable_placeholders="observableParameter1_obs1",
+        noise_placeholders="noiseParameter1_obs1",
     )
-    assert o.observable_placeholders == {
+    assert o.observable_placeholders == [
         sp.Symbol("observableParameter1_obs1", real=True),
-    }
-    assert o.noise_placeholders == {
+    ]
+    assert o.noise_placeholders == [
         sp.Symbol("noiseParameter1_obs1", real=True)
-    }
-
-    # TODO: this should raise an error
-    #   (numbering is not consecutive / not starting from 1)
-    # TODO: clarify if observableParameter0_obs1 would be allowed
-    #  as regular parameter
-    #
-    # with pytest.raises(ValidationError):
-    #  Observable(id="obs1", formula="observableParameter2_obs1")
+    ]
 
 
 def test_change():


### PR DESCRIPTION
Adapt to the changes in https://github.com/PEtab-dev/PEtab/pull/625.

Placeholders are now listed explicitly.

Closes https://github.com/PEtab-dev/libpetab-python/issues/390.