### PR TITLE
Prettify linter output

### DIFF
--- a/petab/petablint.py
+++ b/petab/petablint.py
@@ -160,17 +160,18 @@ def main():
         try:
             validate(args.yaml_file_name)
         except SchemaValidationError as e:
+            path = ""
             if e.absolute_path:
                 # construct a path to the error location inside the YAML file
                 path = list(e.absolute_path)
                 path = (
-                    path[0] + "".join(f"[{str(p)}]" for p in path[1:]) + ": "
+                    f" at {path[0]}"
+                    + "".join(f"[{str(p)}]" for p in path[1:])
+                    + ": "
                 )
-            else:
-                path = ""
             logger.error(
-                "Provided YAML file does not adhere to PEtab schema: "
-                f"{path}{e.args[0]}"
+                "Provided YAML file does not adhere to the PEtab schema"
+                f"{path}: {e.args[0]}"
             )
             sys.exit(1)
         except ValueError as e:

--- a/petab/petablint.py
+++ b/petab/petablint.py
@@ -160,9 +160,21 @@ def main():
         try:
             validate(args.yaml_file_name)
         except SchemaValidationError as e:
+            if e.absolute_path:
+                # construct a path to the error location inside the YAML file
+                path = list(e.absolute_path)
+                path = (
+                    path[0] + "".join(f"[{str(p)}]" for p in path[1:]) + ": "
+                )
+            else:
+                path = ""
             logger.error(
-                f"Provided YAML file does not adhere to PEtab schema: {e}"
+                "Provided YAML file does not adhere to PEtab schema: "
+                f"{path}{e.args[0]}"
             )
+            sys.exit(1)
+        except ValueError as e:
+            logger.error(e)
             sys.exit(1)
 
         if petab.is_composite_problem(args.yaml_file_name):

--- a/petab/v1/yaml.py
+++ b/petab/v1/yaml.py
@@ -77,16 +77,14 @@ def validate_yaml_syntax(
         #  but let's still use the latest PEtab schema for full validation
         version = yaml_config.get(FORMAT_VERSION, None)
         version = (
-            parse_version(version)[:2]
-            if version
-            else list(SCHEMAS.values())[-1]
+            parse_version(version)[:2] if version else list(SCHEMAS.keys())[-1]
         )
 
         try:
             schema = SCHEMAS[version]
         except KeyError as e:
             raise ValueError(
-                "Unknown PEtab version given in problem "
+                "No or unknown PEtab version given in problem "
                 f"specification: {version}"
             ) from e
     schema = load_yaml(schema)


### PR DESCRIPTION
Prettify linter output in case of schema violations in the problem yaml file. Previously, the messages were rather confusing.

Also fix an error message and a bug in the default schema choice.

Related to #369.