### PR TITLE
v2: Paths as pathlib.Path & validate assignment

### DIFF
--- a/petab/v1/yaml.py
+++ b/petab/v1/yaml.py
@@ -242,7 +242,7 @@ def write_yaml(yaml_config: dict[str, Any], filename: str | Path) -> None:
     """
     Path(filename).parent.mkdir(parents=True, exist_ok=True)
     with open(filename, "w") as outfile:
-        yaml.dump(
+        yaml.safe_dump(
             yaml_config, outfile, default_flow_style=False, sort_keys=False
         )
 

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -204,7 +204,10 @@ class Observable(BaseModel):
 
     #: :meta private:
     model_config = ConfigDict(
-        arbitrary_types_allowed=True, populate_by_name=True, extra="allow"
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+        extra="allow",
+        validate_assignment=True,
     )
 
     @field_validator(
@@ -344,6 +347,7 @@ class Change(BaseModel):
         populate_by_name=True,
         use_enum_values=True,
         extra="allow",
+        validate_assignment=True,
     )
 
     @field_validator("target_value", mode="before")
@@ -385,7 +389,9 @@ class Condition(BaseModel):
     changes: list[Change]
 
     #: :meta private:
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(
+        populate_by_name=True, extra="allow", validate_assignment=True
+    )
 
     def __add__(self, other: Change) -> Condition:
         """Add a change to the set."""
@@ -503,7 +509,9 @@ class ExperimentPeriod(BaseModel):
     condition_ids: list[str] = Field(default_factory=list)
 
     #: :meta private:
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(
+        populate_by_name=True, extra="allow", validate_assignment=True
+    )
 
     @field_validator("condition_ids", mode="before")
     @classmethod
@@ -544,7 +552,10 @@ class Experiment(BaseModel):
 
     #: :meta private:
     model_config = ConfigDict(
-        arbitrary_types_allowed=True, populate_by_name=True, extra="allow"
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+        extra="allow",
+        validate_assignment=True,
     )
 
     def __add__(self, other: ExperimentPeriod) -> Experiment:
@@ -682,7 +693,10 @@ class Measurement(BaseModel):
 
     #: :meta private:
     model_config = ConfigDict(
-        arbitrary_types_allowed=True, populate_by_name=True, extra="allow"
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+        extra="allow",
+        validate_assignment=True,
     )
 
     @field_validator(
@@ -806,7 +820,9 @@ class Mapping(BaseModel):
     )
 
     #: :meta private:
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(
+        populate_by_name=True, extra="allow", validate_assignment=True
+    )
 
 
 class MappingTable(BaseModel):
@@ -909,6 +925,7 @@ class Parameter(BaseModel):
         populate_by_name=True,
         use_enum_values=True,
         extra="allow",
+        validate_assignment=True,
     )
 
     @field_validator("id")

--- a/tests/v2/test_problem.py
+++ b/tests/v2/test_problem.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
+from pydantic import AnyUrl
 
 import petab.v2 as petab
 from petab.v2 import Problem
@@ -198,3 +199,29 @@ def test_sample_startpoint_shape():
     n_starts = 10
     sp = problem.sample_parameter_startpoints(n_starts=n_starts)
     assert sp.shape == (n_starts, 2)
+
+
+def test_problem_config_paths():
+    """Test handling of URLS and local paths in ProblemConfig."""
+
+    pc = petab.ProblemConfig(
+        parameter_files=["https://example.com/params.tsv"],
+        condition_files=["conditions.tsv"],
+        measurement_files=["measurements.tsv"],
+        observable_files=["observables.tsv"],
+        experiment_files=["experiments.tsv"],
+    )
+    assert isinstance(pc.parameter_files[0], AnyUrl)
+    assert isinstance(pc.condition_files[0], Path)
+    assert isinstance(pc.measurement_files[0], Path)
+    assert isinstance(pc.observable_files[0], Path)
+    assert isinstance(pc.experiment_files[0], Path)
+
+    # Auto-convert to Path on assignment
+    pc.parameter_files = ["foo.tsv"]
+    assert isinstance(pc.parameter_files[0], Path)
+
+    # We can't easily intercept mutations to the list:
+    #  pc.parameter_files[0] = "foo.tsv"
+    #  assert isinstance(pc.parameter_files[0], Path)
+    # see also https://github.com/pydantic/pydantic/issues/8575


### PR DESCRIPTION
For petab.v2 pydantic models, change path attributes to `pathlib.Path`, and validate assignments.