### PR TITLE
v1v2-converter: handle log10-normal

### DIFF
--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import warnings
 from contextlib import suppress
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -385,6 +386,16 @@ def v1v2_observable_df(observable_df: pd.DataFrame) -> pd.DataFrame:
                 new_dist = dist
             else:
                 new_dist = f"{trans}-{dist}"
+
+            if new_dist == "log10-normal":
+                warnings.warn(
+                    f"Noise distribution `{new_dist}' for "
+                    f"observable `{row[v1.C.OBSERVABLE_ID]}'"
+                    f" is not supported in PEtab v2. "
+                    "Using `log-normal` instead.",
+                    stacklevel=2,
+                )
+                new_dist = v2.C.LOG_NORMAL
 
             if new_dist not in v2.C.NOISE_DISTRIBUTIONS:
                 raise NotImplementedError(

--- a/tests/v2/test_conversion.py
+++ b/tests/v2/test_conversion.py
@@ -30,6 +30,9 @@ except ImportError:
     )
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*Using `log-normal` instead.*:UserWarning"
+)
 @parametrize_or_skip
 def test_benchmark_collection(problem_id):
     """Test that we can upgrade all benchmark collection models."""


### PR DESCRIPTION
PEtab v2 does not support log10-type noise distributions. When upconverting PEtab v1 problems, replace log10-normal by log-normal and emit a warning.