### PR TITLE
v2: Store path info in *Table objects

### DIFF
--- a/petab/_utils.py
+++ b/petab/_utils.py
@@ -1,0 +1,35 @@
+"""Private, version-independent utility functions for PEtab."""
+
+from pathlib import Path
+
+from pydantic import AnyUrl, TypeAdapter
+
+PathOrUrlAdapter = TypeAdapter(AnyUrl | Path)
+
+
+def _generate_path(
+    file_path: str | Path | AnyUrl,
+    base_path: Path | str | AnyUrl | None = None,
+) -> str:
+    """
+    Generate a local path or URL from a file path and an optional base path.
+
+    :return: A string representing the relative or absolute path or URL.
+        Absolute if `file_path` or `base_path` is an absolute path or URL,
+        relative otherwise.
+    """
+    if base_path is None:
+        return str(file_path)
+
+    file_path = PathOrUrlAdapter.validate_python(file_path)
+    if isinstance(file_path, AnyUrl):
+        # if URL, this is absolute
+        return str(file_path)
+
+    base_path = PathOrUrlAdapter.validate_python(base_path)
+    if isinstance(base_path, Path):
+        # if file_path is absolute, base_path will be ignored
+        return str(base_path / file_path)
+
+    # combine URL parts
+    return f"{base_path}/{file_path}"

--- a/petab/v1/models/model.py
+++ b/petab/v1/models/model.py
@@ -21,17 +21,22 @@ class Model(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def from_file(filepath_or_buffer: Any, model_id: str) -> Model:
+    def from_file(
+        filepath_or_buffer: Any, model_id: str, base_path: str | Path = None
+    ) -> Model:
         """Load the model from the given path/URL
 
-        :param filepath_or_buffer: URL or path of the model
+        :param filepath_or_buffer:
+            Absolute or relative path/URL to the model file.
+            If relative, it is interpreted relative to `base_path` if given.
+        :param base_path: Base path for relative paths in the model file.
         :param model_id: Model ID
         :returns: A ``Model`` instance holding the given model
         """
         ...
 
     @abc.abstractmethod
-    def to_file(self, filename: [str, Path]):
+    def to_file(self, filename: str | Path | None = None):
         """Save the model to the given file
 
         :param filename: Destination filename
@@ -131,11 +136,16 @@ class Model(abc.ABC):
 
 
 def model_factory(
-    filepath_or_buffer: Any, model_language: str, model_id: str = None
+    filepath_or_buffer: Any,
+    model_language: str,
+    model_id: str = None,
+    base_path: str | Path = None,
 ) -> Model:
     """Create a PEtab model instance from the given model
 
-    :param filepath_or_buffer: Path/URL of the model
+    :param filepath_or_buffer: Path/URL of the model.
+        Absolute or relative to `base_path` if given.
+    :param base_path: Base path for relative paths in the model file.
     :param model_language: PEtab model language ID for the given model
     :param model_id: PEtab model ID for the given model
     :returns: A :py:class:`Model` instance representing the given model
@@ -145,12 +155,16 @@ def model_factory(
     if model_language == MODEL_TYPE_SBML:
         from .sbml_model import SbmlModel
 
-        return SbmlModel.from_file(filepath_or_buffer, model_id=model_id)
+        return SbmlModel.from_file(
+            filepath_or_buffer, model_id=model_id, base_path=base_path
+        )
 
     if model_language == MODEL_TYPE_PYSB:
         from .pysb_model import PySBModel
 
-        return PySBModel.from_file(filepath_or_buffer, model_id=model_id)
+        return PySBModel.from_file(
+            filepath_or_buffer, model_id=model_id, base_path=base_path
+        )
 
     if model_language in known_model_types:
         raise NotImplementedError(

--- a/petab/v1/models/model.py
+++ b/petab/v1/models/model.py
@@ -28,7 +28,7 @@ class Model(abc.ABC):
 
         :param filepath_or_buffer:
             Absolute or relative path/URL to the model file.
-            If relative, it is interpreted relative to `base_path` if given.
+            If relative, it is interpreted relative to `base_path`, if given.
         :param base_path: Base path for relative paths in the model file.
         :param model_id: Model ID
         :returns: A ``Model`` instance holding the given model

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -1402,7 +1402,12 @@ class Problem:
         by the `rel_path` and `base_path` of their respective objects.
 
         This expects that all objects have their `rel_path` and `base_path`
-        set correctly, which is usually done by Problem.from_yaml().
+        set correctly, which is usually done by :meth:`Problem.from_yaml`.
+
+        :param base_path:
+            The base path the yaml file and tables will be written to.
+            If ``None``, the `base_path` of the individual tables and
+            :obj:`Problem.config.base_path` will be used.
         """
         config = copy.deepcopy(self.config) or ProblemConfig(
             format_version="2.0.0"

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -1399,7 +1399,7 @@ class Problem:
 
         Writes the model, condition, experiment, measurement, parameter,
         observable, and mapping tables to their respective files as specified
-        in the respective objects.
+        by the `rel_path` and `base_path` of their respective objects.
 
         This expects that all objects have their `rel_path` and `base_path`
         set correctly, which is usually done by Problem.from_yaml().


### PR DESCRIPTION
Store path info in `*Table` and `Model` objects to make it easier to read, modify, write complete PEtab problem.

Add `Problem.to_files()`.

Closes #412.