### PR TITLE
Update v2 condition table `targetValue` validation

### DIFF
--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -285,6 +285,9 @@ RESIDUAL = "residual"
 #: separator for multiple parameter values (bounds, observableParameters, ...)
 PARAMETER_SEPARATOR = ";"
 
+#: The time symbol for use in any PEtab-specific mathematical expressions
+TIME_SYMBOL = "time"
+
 
 __all__ = [
     x

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -2125,8 +2125,23 @@ class Problem:
         is added to the last one.
 
         :param id_: The experiment ID.
-        :param args: Timepoints and associated conditions:
-            ``time_1, condition_id_1, time_2, condition_id_2, ...``.
+        :param args: Timepoints and associated conditions
+            (single condition ID as string or multiple condition IDs as lists
+            of strings).
+
+        :example:
+        >>> p = Problem()
+        >>> p.add_experiment(
+        ...     "experiment1",
+        ...     1,
+        ...     "condition1",
+        ...     2,
+        ...     ["condition2a", "condition2b"],
+        ... )
+        >>> p.experiments[0]  # doctest: +NORMALIZE_WHITESPACE
+        Experiment(id='experiment1', periods=[\
+ExperimentPeriod(time=1.0, condition_ids=['condition1']), \
+ExperimentPeriod(time=2.0, condition_ids=['condition2a', 'condition2b'])])
         """
         if len(args) % 2 != 0:
             raise ValueError(


### PR DESCRIPTION
After https://github.com/PEtab-dev/PEtab/pull/645, any condition that is used as a first condition cannot refer to any symbols other then the parameters listed in the parameter table, or `time'.

Closes https://github.com/PEtab-dev/libpetab-python/issues/424.