### PR TITLE
Optional `experimentId` in `Problem.add_measurement`

### DIFF
--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -2035,9 +2035,10 @@ class Problem:
     def add_measurement(
         self,
         obs_id: str,
-        experiment_id: str,
+        *,
         time: float,
         measurement: float,
+        experiment_id: str | None = None,
         observable_parameters: Sequence[str | float] | str | float = None,
         noise_parameters: Sequence[str | float] | str | float = None,
     ):

--- a/tests/v2/test_core.py
+++ b/tests/v2/test_core.py
@@ -389,7 +389,12 @@ def test_problem_from_yaml_multiple_files():
                 problem.experiment_df, Path(tmpdir, f"experiments{i}.tsv")
             )
 
-            problem.add_measurement(f"observable{i}", f"experiment{i}", 1, 1)
+            problem.add_measurement(
+                f"observable{i}",
+                experiment_id=f"experiment{i}",
+                time=1,
+                measurement=1,
+            )
             petab.write_measurement_df(
                 problem.measurement_df, Path(tmpdir, f"measurements{i}.tsv")
             )


### PR DESCRIPTION
Measurements don't require an experiment ID. Therefore, make `experimentId` optional in `Problem.add_measurement`. Also, require keyword arguments there.