### PR TITLE
Update `ExperimentsToEventsConverter` to changed initialization semantics

### DIFF
--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -283,14 +283,18 @@ class ExperimentsToSbmlConverter:
                     target = model.getElementBySId(target_id)
                     default = self._initial_value_from_element(target)
 
-                # combine all changes into a single piecewise expression
+                # Only create the initial assignment if there is
+                #  actually something to change.
                 if expr_cond_pairs := [
                     (target_value, sp.Symbol(exp_ind) > 0.5)
                     for exp_ind, target_value in changes
                     if target_value != default
                 ]:
-                    # only create the initial assignment if there is
-                    #  actually something to change
+                    # Unlike events, we can't have different initial
+                    #  assignments for different experiments, so we need to
+                    #  combine all changes into a single piecewise
+                    #  expression.
+
                     expr = sp.Piecewise(
                         *expr_cond_pairs,
                         (default, True),

--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -20,14 +20,14 @@ from .core import (
 from .models._sbml_utils import add_sbml_parameter, check
 from .models.sbml_model import SbmlModel
 
-__all__ = ["ExperimentsToEventsConverter"]
+__all__ = ["ExperimentsToSbmlConverter"]
 
 
-class ExperimentsToEventsConverter:
-    """Convert PEtab experiments to SBML events.
+class ExperimentsToSbmlConverter:
+    """Convert PEtab experiments to SBML.
 
     For an SBML-model-based PEtab problem, this class converts the PEtab
-    experiments to events as far as possible.
+    experiments to initial assignments and events as far as possible.
 
     If the model already contains events, PEtab events are added with a higher
     priority than the existing events to guarantee that PEtab condition changes
@@ -38,8 +38,8 @@ class ExperimentsToEventsConverter:
     The PEtab problem must not contain any identifiers starting with
     ``_petab``.
 
-    All periods and condition changes that are represented by events
-    will be removed from the condition table.
+    All periods and condition changes that are represented by initial
+    assignments or events will be removed from the condition table.
     Each experiment will have at most one period with a start time of ``-inf``
     and one period with a finite start time. The associated changes with
     these periods are only the pre-equilibration indicator
@@ -454,7 +454,7 @@ class ExperimentsToEventsConverter:
         :param changes: The PEtab condition changes that are to be applied
             at the start of the period.
         """
-        _add_assignment = ExperimentsToEventsConverter._add_assignment
+        _add_assignment = ExperimentsToSbmlConverter._add_assignment
         sbml_model = event.getModel()
         # collect IDs of compartments that are changed in this period
         changed_compartments = {

--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -221,7 +221,7 @@ class ExperimentsToSbmlConverter:
         # Collect values for initial assignments for the different experiments.
         #  All expressions must be combined into a single initial assignment
         #  per target.
-        # target_id -> (experiment_indicator, target_value)
+        # target_id -> [(experiment_indicator, target_value), ...]
         period0_assignments: dict[str, list[tuple[str, sp.Basic]]] = {}
 
         for i_period, period in enumerate(experiment.sorted_periods):
@@ -330,7 +330,14 @@ class ExperimentsToSbmlConverter:
 
     @staticmethod
     def _initial_value_from_element(target: libsbml.SBase) -> sp.Basic:
-        # use the initial value of the target as default
+        """Get the initial value of an SBML element.
+
+        The value to the size attribute of compartments,
+        the initial concentration or amount of species (amount for
+        `hasOnlySubstanceUnits=true`, concentration otherwise), and
+        the value of parameters, not considering any initial assignment
+        constructs.
+        """
         if target is None:
             raise ValueError("`target` is None.")
 

--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -248,11 +248,11 @@ class ExperimentsToSbmlConverter:
             #  Additionally, tools that don't support events can still handle
             #  single-period experiments.
             if i_period == 0:
-                exp_ind = self.get_experiment_indicator(experiment.id)
+                exp_ind_id = self.get_experiment_indicator(experiment.id)
                 for change in self._new_problem.get_changes_for_period(period):
                     period0_assignments.setdefault(
                         change.target_id, []
-                    ).append((exp_ind, change.target_value))
+                    ).append((exp_ind_id, change.target_value))
             else:
                 ev = self._create_period_start_event(
                     experiment=experiment,
@@ -332,7 +332,7 @@ class ExperimentsToSbmlConverter:
     def _initial_value_from_element(target: libsbml.SBase) -> sp.Basic:
         """Get the initial value of an SBML element.
 
-        The value to the size attribute of compartments,
+        The value of the size attribute of compartments,
         the initial concentration or amount of species (amount for
         `hasOnlySubstanceUnits=true`, concentration otherwise), and
         the value of parameters, not considering any initial assignment
@@ -530,7 +530,7 @@ class ExperimentsToSbmlConverter:
             ):
                 # Handle any changes other than compartments and
                 #  concentration-based species inside resized compartments
-                #  that we were already handled above.
+                #  that we already handled above.
                 # Those translate directly to event assignments.
                 _add_assignment(event, change.target_id, change.target_value)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ maintainers = [
 [project.optional-dependencies]
 tests = [
     "antimony>=2.14.0",
+    "copasi-basico>=0.85",
     "pysb",
     "pytest",
     "pytest-cov",

--- a/tests/v2/test_converters.py
+++ b/tests/v2/test_converters.py
@@ -26,7 +26,8 @@ def test_experiments_to_events_converter():
     assert isinstance(converted.model, SbmlModel)
     sbml_model = converted.model.sbml_model
 
-    assert sbml_model.getNumEvents() == 2
+    # one event -- the initial period is handled via initial assignments
+    assert sbml_model.getNumEvents() == 1
     assert converted.conditions == [
         Condition(
             id="_petab_preequilibration_on",
@@ -211,7 +212,6 @@ def test_simulate_experiment_to_events():
         "_petab_experiment_indicator_e1"
     ).setValue(1)
     sbml_actual = converted.model.to_sbml_str()
-    print(converted.model.to_antimony())
     basico.load_model(sbml_actual)
     df_actual = basico.run_time_course(values=timepoints)
 

--- a/tests/v2/test_converters.py
+++ b/tests/v2/test_converters.py
@@ -3,12 +3,12 @@ from math import inf
 import pandas as pd
 
 from petab.v2 import Change, Condition, Experiment, ExperimentPeriod, Problem
-from petab.v2.converters import ExperimentsToEventsConverter
+from petab.v2.converters import ExperimentsToSbmlConverter
 from petab.v2.models.sbml_model import SbmlModel
 
 
 def test_experiments_to_events_converter():
-    """Test the ExperimentsToEventsConverter."""
+    """Test the ExperimentsToSbmlConverter."""
     ant_model = """
     species X = 0
     X' = 1
@@ -19,7 +19,7 @@ def test_experiments_to_events_converter():
     problem.add_condition("c2", X=2)
     problem.add_experiment("e1", -inf, "c1", 10, "c2")
 
-    converter = ExperimentsToEventsConverter(problem)
+    converter = ExperimentsToSbmlConverter(problem)
     converted = converter.convert()
     assert converted.validate().has_errors() is False
 
@@ -204,7 +204,7 @@ def test_simulate_experiment_to_events():
     problem.assert_valid()
 
     # convert PEtab experiments to SBML events and simulate in BasiCO
-    converter = ExperimentsToEventsConverter(problem)
+    converter = ExperimentsToSbmlConverter(problem)
     converted = converter.convert()
     # set experiment indicator to simulate experiment "e1"
     converted.model.sbml_model.getParameter(

--- a/tests/v2/test_converters.py
+++ b/tests/v2/test_converters.py
@@ -1,5 +1,7 @@
 from math import inf
 
+import pandas as pd
+
 from petab.v2 import Change, Condition, Experiment, ExperimentPeriod, Problem
 from petab.v2.converters import ExperimentsToEventsConverter
 from petab.v2.models.sbml_model import SbmlModel
@@ -74,3 +76,156 @@ def test_experiments_to_events_converter():
             ],
         ),
     ]
+
+
+def test_simulate_experiment_to_events():
+    """
+    Convert PEtab experiment to SBML events and compare BasiCO simulation
+    results.
+    """
+    import basico
+
+    # the basic model for the PEtab problem
+    ant_model1 = """
+    compartment comp1 = 10
+    compartment comp2 = 2
+    # concentration-based species
+    species s1c_comp1 in comp1 = 1
+    species s1c_comp2 in comp2 = 2
+    species s2c_comp1 in comp1 = 3
+    species s2c_comp2 in comp2 = 4
+    # amount-based species
+    # (note: the initial values are concentrations nonetheless)
+    substanceOnly species s3a_comp1 in comp1 = 5
+    substanceOnly species s3a_comp2 in comp2 = 6
+    substanceOnly species s4a_comp1 in comp1 = 7
+    substanceOnly species s4a_comp2 in comp2 = 8
+
+    # something dynamic
+    some_species in comp1 = 0
+    some_species' = 1
+
+    # set time-derivatives, otherwise BasiCO won't include them in the result
+    s1c_comp1' = 0
+    s1c_comp2' = 0
+    s2c_comp1' = 0
+    s2c_comp2' = 0
+    s3a_comp1' = 0
+    s3a_comp2' = 0
+    s4a_comp1' = 0
+    s4a_comp2' = 0
+    """
+
+    # append events, equivalent to the expected PEtab conversion result
+    ant_model_expected = (
+        ant_model1
+        + """
+    # resize compartment
+    # The size of comp1 should be set to 20, the concentrations of the
+    # contained concentration-based species and the amounts of the amount-based
+    # species should remain unchanged. comp2 and everything therein is
+    # unaffected.
+    # I.e., post-event:
+    #   s1c_comp1 = 1, s2c_comp1 = 3, s3a_comp1 = 5, s4a_comp1 = 7
+    at time >= 1:
+        comp1 = 20,
+        s1c_comp1 = s1c_comp1 * 20 / comp1,
+        s2c_comp1 = s2c_comp1 * 20 / comp1;
+
+    # resize compartment *and* reassign concentration
+    # The size of comp2 should be set to 4, the concentration/amount of
+    # s1c_comp2/s3a_comp2 should be set to the given values,
+    # the amounts for amount-based and concentrations for concentration-based
+    # other species in comp2 should remain unchanged.
+    # I.e., post-event:
+    #   comp2 = 4
+    #   s1c_comp2 = 5, s3a_comp2 = 16,
+    #   s2c_comp2 = 4 (unchanged), s4a_comp2 = 8 (unchanged)
+    # The post-event concentrations of concentration-based species are
+    # (per SBML):
+    #   new_conc = assigned_amount / new_volume
+    #            = assigned_conc * old_volume / new_volume
+    #   <=> assigned_conc = new_conc * new_volume / old_volume
+    # The post-event amounts of amount-based species are:
+    #   new_amount = assigned_amount (independent of volume change)
+    at time >= 5:
+        comp2 = 4,
+        s3a_comp2 = 16,
+        s1c_comp2 = 5 * 4 / comp2,
+        s2c_comp2 = s2c_comp2 * 4 / comp2;
+    """
+    )
+
+    # simulate expected model in BasiCO
+    sbml_expected = SbmlModel.from_antimony(ant_model_expected).to_sbml_str()
+    basico.load_model(sbml_expected)
+    # output timepoints (initial, pre-/post-event, ...)
+    timepoints = [0, 0.9, 1.1, 4.9, 5.1, 10]
+    # Simulation will return all species as concentrations
+    df_expected = basico.run_time_course(values=timepoints)
+    # fmt: off
+    assert (
+            df_expected
+            == pd.DataFrame(
+            {'Values[some_species]': {0.0: 0.0, 0.9: 0.9,
+                                      1.1: 1.0999999999999996, 4.9: 4.9,
+                                      5.1: 5.100000000000001, 10.0: 10.0},
+             's1c_comp1': {0.0: 1.0, 0.9: 1.0, 1.1: 1.0, 4.9: 1.0, 5.1: 1.0,
+                           10.0: 1.0},
+             's2c_comp1': {0.0: 3.0, 0.9: 3.0, 1.1: 3.0, 4.9: 3.0, 5.1: 3.0,
+                           10.0: 3.0},
+             's3a_comp1': {0.0: 5.0, 0.9: 5.0, 1.1: 2.5, 4.9: 2.5, 5.1: 2.5,
+                           10.0: 2.5},
+             's4a_comp1': {0.0: 7.0, 0.9: 7.0, 1.1: 3.5, 4.9: 3.5, 5.1: 3.5,
+                           10.0: 3.5},
+             's1c_comp2': {0.0: 2.0, 0.9: 2.0, 1.1: 2.0, 4.9: 2.0, 5.1: 5.0,
+                           10.0: 5.0},
+             's2c_comp2': {0.0: 4.0, 0.9: 4.0, 1.1: 4.0, 4.9: 4.0, 5.1: 4.0,
+                           10.0: 4.0},
+             's3a_comp2': {0.0: 6.0, 0.9: 6.0, 1.1: 6.0, 4.9: 6.0, 5.1: 4.0,
+                           10.0: 4.0},
+             's4a_comp2': {0.0: 8.0, 0.9: 8.0, 1.1: 8.0, 4.9: 8.0, 5.1: 4.0,
+                           10.0: 4.0},
+             'Compartments[comp1]': {0.0: 10.0, 0.9: 10.0, 1.1: 20.0,
+                                     4.9: 20.0, 5.1: 20.0, 10.0: 20.0},
+             'Compartments[comp2]': {0.0: 2.0, 0.9: 2.0, 1.1: 2.0, 4.9: 2.0,
+                                     5.1: 4.0, 10.0: 4.0}}
+        )
+    ).all().all()
+    # fmt: on
+
+    # construct PEtab test problem
+    problem = Problem()
+    problem.model = SbmlModel.from_antimony(ant_model1)
+    problem.add_condition("c1", comp1=20)
+    problem.add_condition("c2", comp2=4, s1c_comp2=5, s3a_comp2=16)
+    problem.add_experiment("e1", 1, "c1", 5, "c2")
+    problem.assert_valid()
+
+    # convert PEtab experiments to SBML events and simulate in BasiCO
+    converter = ExperimentsToEventsConverter(problem)
+    converted = converter.convert()
+    # set experiment indicator to simulate experiment "e1"
+    converted.model.sbml_model.getParameter(
+        "_petab_experiment_indicator_e1"
+    ).setValue(1)
+    sbml_actual = converted.model.to_sbml_str()
+    basico.load_model(sbml_actual)
+    df_actual = basico.run_time_course(values=timepoints)
+
+    # compare results
+    with pd.option_context(
+        "display.max_rows",
+        None,
+        "display.max_columns",
+        None,
+        "display.width",
+        None,
+    ):
+        print("Expected:")
+        print(df_expected)
+        print("Actual:")
+        print(df_actual)
+
+    for col in df_expected.columns:
+        assert (df_expected[col] == df_actual[col]).all()

--- a/tests/v2/test_converters.py
+++ b/tests/v2/test_converters.py
@@ -197,9 +197,10 @@ def test_simulate_experiment_to_events():
     # construct PEtab test problem
     problem = Problem()
     problem.model = SbmlModel.from_antimony(ant_model1)
+    problem.add_condition("c0", comp1=10)
     problem.add_condition("c1", comp1=20)
     problem.add_condition("c2", comp2=4, s1c_comp2=5, s3a_comp2=16)
-    problem.add_experiment("e1", 1, "c1", 5, "c2")
+    problem.add_experiment("e1", 0, "c0", 1, "c1", 5, "c2")
     problem.assert_valid()
 
     # convert PEtab experiments to SBML events and simulate in BasiCO
@@ -210,6 +211,7 @@ def test_simulate_experiment_to_events():
         "_petab_experiment_indicator_e1"
     ).setValue(1)
     sbml_actual = converted.model.to_sbml_str()
+    print(converted.model.to_antimony())
     basico.load_model(sbml_actual)
     df_actual = basico.run_time_course(values=timepoints)
 


### PR DESCRIPTION
Due to https://github.com/PEtab-dev/PEtab/pull/645 ...
* ... the first period of a PEtab experiment has to be applied before initial assignments are evaluated. That means, the changes have to be implemented as initial assignments instead of event assignments at the initial timepoint (or any pre-existing initial assignments would have to be included in the event assignment).
* ... for any subsequent periods, the event assignments need to be modified. Compartment-size changes in PEtab no longer follow the SBML event assignment semantics. That means, we need event assignments for all concentration-based species inside such a compartment to preserve concentrations instead of amounts.  

Closes #452.