### PR TITLE
v2: Remove log10-normal distribution

### DIFF
--- a/petab/v2/C.py
+++ b/petab/v2/C.py
@@ -199,8 +199,6 @@ EXPONENTIAL = "exponential"
 GAMMA = "gamma"
 #: Laplace distribution
 LAPLACE = "laplace"
-#: Log10-normal distribution.
-LOG10_NORMAL = "log10-normal"
 #: Log-Laplace distribution
 LOG_LAPLACE = "log-laplace"
 #: Log-normal distribution
@@ -221,7 +219,6 @@ PRIOR_DISTRIBUTIONS = [
     EXPONENTIAL,
     GAMMA,
     LAPLACE,
-    LOG10_NORMAL,
     LOG_LAPLACE,
     LOG_NORMAL,
     LOG_UNIFORM,

--- a/petab/v2/calculate.py
+++ b/petab/v2/calculate.py
@@ -447,10 +447,7 @@ def calculate_single_llh(
         The computed likelihood for the given values.
     """
     # PEtab v2:
-    if noise_distribution == LOG10_NORMAL and scale == LIN:
-        noise_distribution = NORMAL
-        scale = LOG10
-    elif noise_distribution == LOG_NORMAL and scale == LIN:
+    if noise_distribution == LOG_NORMAL and scale == LIN:
         noise_distribution = NORMAL
         scale = LOG
 

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -148,8 +148,6 @@ class NoiseDistribution(str, Enum):
     LOG_NORMAL = C.LOG_NORMAL
     #: Log-Laplace distribution
     LOG_LAPLACE = C.LOG_LAPLACE
-    #: Log10-Normal
-    LOG10_NORMAL = C.LOG10_NORMAL
 
 
 class PriorDistribution(str, Enum):
@@ -168,8 +166,6 @@ class PriorDistribution(str, Enum):
     GAMMA = C.GAMMA
     #: Laplace distribution.
     LAPLACE = C.LAPLACE
-    #: Log10-normal distribution.
-    LOG10_NORMAL = C.LOG10_NORMAL
     #: Log-Laplace distribution
     LOG_LAPLACE = C.LOG_LAPLACE
     #: Log-normal distribution.
@@ -195,7 +191,6 @@ _prior_to_cls = {
     PriorDistribution.EXPONENTIAL: Exponential,
     PriorDistribution.GAMMA: Gamma,
     PriorDistribution.LAPLACE: Laplace,
-    PriorDistribution.LOG10_NORMAL: Normal,
     PriorDistribution.LOG_LAPLACE: Laplace,
     PriorDistribution.LOG_NORMAL: Normal,
     PriorDistribution.LOG_UNIFORM: Uniform,

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -802,7 +802,6 @@ class CheckPriorDistribution(ValidationTask):
         PriorDistribution.EXPONENTIAL: 1,
         PriorDistribution.GAMMA: 2,
         PriorDistribution.LAPLACE: 2,
-        PriorDistribution.LOG10_NORMAL: 2,
         PriorDistribution.LOG_LAPLACE: 2,
         PriorDistribution.LOG_NORMAL: 2,
         PriorDistribution.LOG_UNIFORM: 2,

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -59,7 +59,7 @@ def petab1to2(
         return v2.Problem.from_yaml(Path(tmp_dir, Path(yaml_config).name))
 
 
-def petab_files_1to2(yaml_config: Path | str, output_dir: Path | str):
+def petab_files_1to2(yaml_config: Path | str | dict, output_dir: Path | str):
     """Convert PEtab files from PEtab 1.0 to PEtab 2.0.
 
 
@@ -404,7 +404,8 @@ def v1v2_observable_df(observable_df: pd.DataFrame) -> pd.DataFrame:
                     f"observable `{row[v1.C.OBSERVABLE_ID]}'"
                     f" is not supported in PEtab v2. "
                     "Using `log-normal` instead.",
-                    stacklevel=2,
+                    # call to `petab1to2`
+                    stacklevel=9,
                 )
                 new_dist = v2.C.LOG_NORMAL
 
@@ -490,10 +491,20 @@ def v1v2_parameter_df(
         if pscale != v1.C.LIN:
             new_prior_type = f"{pscale}-{new_prior_type}"
 
+        if new_prior_type == "log10-normal":
+            warnings.warn(
+                f"Prior distribution `{new_prior_type}' for parameter "
+                f"`{row.name}' is not supported in PEtab v2. "
+                "Using `log-normal` instead.",
+                # call to `petab1to2`
+                stacklevel=9,
+            )
+            new_prior_type = v2.C.LOG_NORMAL
+
         if new_prior_type not in v2.C.PRIOR_DISTRIBUTIONS:
             raise NotImplementedError(
                 f"PEtab v2 does not support prior type `{new_prior_type}' "
-                f"required for parameter `{row.index}'."
+                f"required for parameter `{row.name}'."
             )
 
         return new_prior_type


### PR DESCRIPTION
Remove LOG10_NORMAL from `petab.v2.{PriorDistribution,NoiseDistribution}` which has been removed from PEtab v2 (https://github.com/PEtab-dev/PEtab/pull/644). Also update v1->v2 conversion accordingly.

Closes #455.