### PR TITLE
Remove petab.v2-is-experimental warnings

### DIFF
--- a/petab/v1/problem.py
+++ b/petab/v1/problem.py
@@ -302,7 +302,6 @@ class Problem:
                 f"{yaml_config[FORMAT_VERSION]}."
             )
         if major_version == 2:
-            warn("Support for PEtab2.0 is experimental!", stacklevel=2)
             warn(
                 "Using petab.v1.Problem with PEtab2.0 is deprecated. "
                 "Use petab.v2.Problem instead.",

--- a/petab/v2/__init__.py
+++ b/petab/v2/__init__.py
@@ -3,14 +3,6 @@
 Contains all functionality related to handling PEtab 2.0 problems.
 """
 
-from warnings import warn
-
-warn(
-    "Support for PEtab2.0 and all of petab.v2 is experimental "
-    "and subject to changes!",
-    stacklevel=1,
-)
-
 # TODO: move this module to v2
 from petab.v1.mapping import (  # noqa: F403, F401, E402
     get_mapping_df,

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,5 @@ filterwarnings =
     error
     # TODO: until tests are reorganized for petab.v1
     ignore::DeprecationWarning
-    ignore:Support for PEtab2.0 and all of petab.v2 is experimental:UserWarning
-    ignore:Support for PEtab2.0 is experimental:UserWarning
     ignore:.*inspect.getargspec\(\) is deprecated.*:DeprecationWarning
     ignore:.*Passing unrecognized arguments to super\(PyDevIPCompleter6\).*:DeprecationWarning


### PR DESCRIPTION
This has been communicated via the release notes. I don't think we need to annoy users with these warnings.