### PR TITLE
Minor improvement in v1 to v2 converter

### DIFF
--- a/petab/v2/experiments.py
+++ b/petab/v2/experiments.py
@@ -11,16 +11,14 @@ def get_experiment_df(
     experiments_file: str | pd.DataFrame | Path | None,
 ) -> pd.DataFrame | None:
     """
-    Read the provided observable file into a ``pandas.Dataframe``.
+    Read the provided experiments file into a ``pandas.Dataframe``.
 
     Arguments:
         experiments_file: Name of the file to read from or pandas.Dataframe.
 
     Returns:
-        Observable DataFrame
+        Experiments DataFrame
     """
-    if experiments_file is None:
-        return experiments_file
 
     if isinstance(experiments_file, str | Path):
         experiments_file = pd.read_csv(

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -523,7 +523,9 @@ def v1v2_parameter_df(
         errors="ignore",
     )
     # some columns were dropped in PEtab v2
-    if df[v1.C.INITIALIZATION_PRIOR_TYPE].notna():
+    if v1.C.INITIALIZATION_PRIOR_TYPE in df and (
+        df[v1.C.INITIALIZATION_PRIOR_TYPE].notna()
+    ):
         warnings.warn(
             "Initialisation priors in parameter table are not supported "
             "in PEtab v2.",

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -178,15 +178,15 @@ def petab_files_1to2(yaml_config: Path | str | dict, output_dir: Path | str):
             experiments.append(
                 {
                     v2.C.EXPERIMENT_ID: exp_id,
-                    v2.C.CONDITION_ID: preeq_cond_id,
                     v2.C.TIME: v2.C.TIME_PREEQUILIBRATION,
+                    v2.C.CONDITION_ID: preeq_cond_id,
                 }
             )
         experiments.append(
             {
                 v2.C.EXPERIMENT_ID: exp_id,
-                v2.C.CONDITION_ID: sim_cond_id,
                 v2.C.TIME: 0,
+                v2.C.CONDITION_ID: sim_cond_id,
             }
         )
     if experiments:

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -524,7 +524,7 @@ def v1v2_parameter_df(
     )
     # some columns were dropped in PEtab v2
     if v1.C.INITIALIZATION_PRIOR_TYPE in df and (
-        df[v1.C.INITIALIZATION_PRIOR_TYPE].notna()
+        df[v1.C.INITIALIZATION_PRIOR_TYPE].notna().any()
     ):
         warnings.warn(
             "Initialisation priors in parameter table are not supported "

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -523,6 +523,17 @@ def v1v2_parameter_df(
         errors="ignore",
     )
     # some columns were dropped in PEtab v2
+    if df[v1.C.INITIALIZATION_PRIOR_TYPE].notna():
+        warnings.warn(
+            "Initialisation priors in parameter table are not supported "
+            "in PEtab v2.",
+            stacklevel=9,
+        )
+    if not (df[v1.C.PARAMETER_SCALE] == v1.C.LIN).all():
+        warnings.warn(
+            "Parameter scales are not supported in PEtab v2.",
+            stacklevel=9,
+        )
     df.drop(
         columns=[
             v1.C.INITIALIZATION_PRIOR_TYPE,

--- a/tests/v2/test_conversion.py
+++ b/tests/v2/test_conversion.py
@@ -33,6 +33,13 @@ except ImportError:
 @pytest.mark.filterwarnings(
     "ignore:.*Using `log-normal` instead.*:UserWarning"
 )
+@pytest.mark.filterwarnings(
+    "ignore:.*Initialisation priors in parameter table are not supported.*:"
+    "UserWarning"
+)
+@pytest.mark.filterwarnings(
+    "ignore:.*Parameter scales are not supported in PEtab v2.*:UserWarning"
+)
 @parametrize_or_skip
 def test_benchmark_collection(problem_id):
     """Test that we can upgrade all benchmark collection models."""

--- a/tests/v2/test_core.py
+++ b/tests/v2/test_core.py
@@ -47,6 +47,9 @@ def test_observable_table_round_trip():
         assert observables == observables2
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*Parameter scales are not supported in PEtab v2.*:UserWarning"
+)
 def test_condition_table_round_trip():
     with tempfile.TemporaryDirectory() as tmp_dir:
         petab1to2(example_dir_fujita / "Fujita.yaml", tmp_dir)
@@ -59,6 +62,9 @@ def test_condition_table_round_trip():
         assert conditions == conditions2
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*Parameter scales are not supported in PEtab v2.*:UserWarning"
+)
 def test_assert_valid():
     problem = petab1to2(example_dir_fujita / "Fujita.yaml")
     problem.assert_valid()


### PR DESCRIPTION
- add Warning when removing `PARAMETER_SCALE`, `INITIALIZATION_PRIOR_TYPE`, `INITIALIZATION_PRIOR_PARAMETERS`
- Use the column order for the experiments table that is suggested in the PEtab format
- Fix description and redundancy in v2 `get_experiment_df`