### PR TITLE
Lint mapping table

### DIFF
--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -19,6 +19,7 @@ from typing import (
     Annotated,
     Any,
     Generic,
+    Literal,
     Self,
     TypeVar,
     get_args,
@@ -318,9 +319,9 @@ class Observable(BaseModel):
     #: Observable name.
     name: str | None = Field(alias=C.OBSERVABLE_NAME, default=None)
     #: Observable formula.
-    formula: sp.Basic | None = Field(alias=C.OBSERVABLE_FORMULA, default=None)
+    formula: sp.Basic = Field(alias=C.OBSERVABLE_FORMULA)
     #: Noise formula.
-    noise_formula: sp.Basic | None = Field(alias=C.NOISE_FORMULA, default=None)
+    noise_formula: sp.Basic = Field(alias=C.NOISE_FORMULA)
     #: Noise distribution.
     noise_distribution: NoiseDistribution = Field(
         alias=C.NOISE_DISTRIBUTION, default=NoiseDistribution.NORMAL
@@ -926,7 +927,7 @@ class Parameter(BaseModel):
     )
     #: Nominal value.
     nominal_value: Annotated[
-        float | None, BeforeValidator(_convert_nan_to_none)
+        float | Literal["array"] | None, BeforeValidator(_convert_nan_to_none)
     ] = Field(alias=C.NOMINAL_VALUE, default=None)
     #: Is the parameter to be estimated?
     estimate: bool = Field(alias=C.ESTIMATE, default=True)

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -19,7 +19,6 @@ from typing import (
     Annotated,
     Any,
     Generic,
-    Literal,
     Self,
     TypeVar,
     get_args,
@@ -927,7 +926,7 @@ class Parameter(BaseModel):
     )
     #: Nominal value.
     nominal_value: Annotated[
-        float | Literal["array"] | None, BeforeValidator(_convert_nan_to_none)
+        float | None, BeforeValidator(_convert_nan_to_none)
     ] = Field(alias=C.NOMINAL_VALUE, default=None)
     #: Is the parameter to be estimated?
     estimate: bool = Field(alias=C.ESTIMATE, default=True)

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -446,7 +446,7 @@ class CheckUniquePrimaryKeys(ValidationTask):
 
         # check for uniqueness of all primary keys
         counter = Counter(c.id for c in problem.conditions)
-        duplicates = {id_ for id_, count in counter.items() if count > 1}
+        duplicates = sorted(id_ for id_, count in counter.items() if count > 1)
 
         if duplicates:
             return ValidationError(
@@ -454,7 +454,7 @@ class CheckUniquePrimaryKeys(ValidationTask):
             )
 
         counter = Counter(o.id for o in problem.observables)
-        duplicates = {id_ for id_, count in counter.items() if count > 1}
+        duplicates = sorted(id_ for id_, count in counter.items() if count > 1)
 
         if duplicates:
             return ValidationError(
@@ -462,7 +462,7 @@ class CheckUniquePrimaryKeys(ValidationTask):
             )
 
         counter = Counter(e.id for e in problem.experiments)
-        duplicates = {id_ for id_, count in counter.items() if count > 1}
+        duplicates = sorted(id_ for id_, count in counter.items() if count > 1)
 
         if duplicates:
             return ValidationError(
@@ -470,7 +470,7 @@ class CheckUniquePrimaryKeys(ValidationTask):
             )
 
         counter = Counter(p.id for p in problem.parameters)
-        duplicates = {id_ for id_, count in counter.items() if count > 1}
+        duplicates = sorted(id_ for id_, count in counter.items() if count > 1)
 
         if duplicates:
             return ValidationError(
@@ -509,7 +509,11 @@ class CheckExperimentTable(ValidationTask):
         for experiment in problem.experiments:
             # Check that there are no duplicate timepoints
             counter = Counter(period.time for period in experiment.periods)
-            duplicates = {time for time, count in counter.items() if count > 1}
+            duplicates = sorted(
+                time
+                for time, count in counter.items()
+                if count > 1
+            )
             if duplicates:
                 messages.append(
                     f"Experiment {experiment.id} contains duplicate "
@@ -904,31 +908,47 @@ class CheckMappingTable(ValidationTask):
 
         # Mapping table is optional
         if problem.mappings:
-            # Check that each id only occurs once
-            counter = Counter(
-                [
-                    getattr(mapping, attr)
-                    for mapping in problem.mappings
-                    for attr in ["petab_id", "model_id"]
-                    if getattr(mapping, attr)
-                ]
+            # Check that each id, across both the petabEntityId and
+            # modelEntityId columns, occurs only once
+            must_be_unique_ids = []
+            for mapping in problem.mappings:
+                petab_id := getattr(mapping, "petab_id"):
+                model_id := getattr(mapping, "model_id"):
+
+                if petab_id:
+                    must_be_unique_ids.append(petab_id)
+                # Duplicates for annotation-only rows (identity mappings)
+                # are permitted.
+                if petab_id == model_id:
+                    continue
+                if model_id:
+                    must_be_unique_ids.append(model_id)
+
+            non_unique_ids = sorted(
+                id_
+                for id_, count in Counter(must_be_unique_ids).items()
+                if count > 1
             )
-            non_unique = {id_ for id_, count in counter.items() if count > 1}
-            if non_unique:
+            if non_unique_ids:
                 return ValidationError(
-                    f"Mapping table contains non-unique IDs: {non_unique}."
+                    f"Mapping table contains non-unique IDs: {non_unique_ids}."
                 )
 
             # petabEntityId is not defined elsewhere in the PEtab problem
-            petab_ids_mapping = {m.petab_id for m in problem.mappings}
-            defined_petab_ids = (
+            new_petab_ids = {
+                m.petab_id
+                for m in problem.mappings
+                # Ignore identity mappings used for annotation
+                if m.petab_id != m.model_id
+            }
+            old_petab_ids = (
                 {c.id for c in problem.conditions}
                 | {e.id for e in problem.experiments}
                 | {o.id for o in problem.observables}
             )
-            if petab_ids_mapping & defined_petab_ids:
+            if overdefined_ids := sorted(new_petab_ids & old_petab_ids):
                 messages.append(
-                    f"PEtab IDs `{petab_ids_mapping & defined_petab_ids}` are "
+                    f"PEtab IDs `{overdefined_ids}` are "
                     "defined in the mapping table but also defined through "
                     "other PEtab tables."
                 )
@@ -989,6 +1009,9 @@ def get_valid_parameters_for_parameter_table(
     )
 
     # Add petab ids from mapping table if they are used for aliasing
+    # FIXME only add mapping.petab_id to allowed parameter IDs list if it
+    #       aliases an invalid PEtab ID? See
+    #       https://github.com/PEtab-dev/libpetab-python/pull/482#discussion_r3420762034
     for mapping in problem.mappings:
         if mapping.model_id and mapping.model_id in parameter_ids.keys():
             parameter_ids[mapping.petab_id] = None

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -554,7 +554,9 @@ class CheckExperimentConditionsExist(ValidationTask):
 
 class CheckAllParametersPresentInParameterTable(ValidationTask):
     """Ensure all required parameters are contained in the parameter table
-    with no additional ones. This also ensures that the mapping table petab ids
+    with no additional ones. 
+    
+    This also ensures that the mapping table petab ids
     are used in the PEtab problem."""
 
     def run(self, problem: Problem) -> ValidationIssue | None:

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -510,9 +510,7 @@ class CheckExperimentTable(ValidationTask):
             # Check that there are no duplicate timepoints
             counter = Counter(period.time for period in experiment.periods)
             duplicates = sorted(
-                time
-                for time, count in counter.items()
-                if count > 1
+                time for time, count in counter.items() if count > 1
             )
             if duplicates:
                 messages.append(
@@ -912,8 +910,8 @@ class CheckMappingTable(ValidationTask):
             # modelEntityId columns, occurs only once
             must_be_unique_ids = []
             for mapping in problem.mappings:
-                petab_id := getattr(mapping, "petab_id"):
-                model_id := getattr(mapping, "model_id"):
+                petab_id = getattr(mapping, "petab_id", None)
+                model_id = getattr(mapping, "model_id", None)
 
                 if petab_id:
                     must_be_unique_ids.append(petab_id)

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -932,16 +932,6 @@ class CheckMappingTable(ValidationTask):
                     "defined in the mapping table but also defined through "
                     "other PEtab tables."
                 )
-            # Grab all symbols from condition table for later
-            condition_target_ids_values = {
-                sym
-                for cond in problem.conditions
-                for change in cond.changes
-                for sym in (
-                    change.target_value.free_symbols
-                    | change.target_id.free_symbols
-                )
-            }
 
             for mapping in problem.mappings:
                 # petabEntityId is not referenced in any model
@@ -952,39 +942,6 @@ class CheckMappingTable(ValidationTask):
                             "table and referenced directly in the model "
                             f"`{model.model_id}`."
                         )
-
-                # modelEntityId can be empty
-                if mapping.model_id:
-                    # model_id is not in petab problem
-                    if mapping.model_id in defined_petab_ids:
-                        messages.append(
-                            f"PEtab ID `{mapping.model_id}` mirrors the "
-                            "model entity ID referenced in the mapping table."
-                        )
-                    if mapping.model_id in condition_target_ids_values:
-                        messages.append(
-                            f"Identifier `{mapping.model_id}` is mapped to a "
-                            "PEtab ID in the mapping table, but also directly "
-                            "used in the conditions table."
-                        )
-                    for observable_formula in [
-                        o.formula for o in problem.observables
-                    ]:
-                        if mapping.model_id in observable_formula.free_symbols:
-                            messages.append(
-                                f"Identifier `{mapping.model_id}` is mapped "
-                                "to a PEtab ID in the mapping table, but also "
-                                "directly used in an observable formula."
-                            )
-                    for obs_noise_formula in [
-                        o.noise_formula for o in problem.observables
-                    ]:
-                        if mapping.model_id in obs_noise_formula.free_symbols:
-                            messages.append(
-                                f"Identifier `{mapping.model_id}` is mapped "
-                                "to a PEtab ID in the mapping table, but also "
-                                "directly used in a noise formula."
-                            )
 
         if messages:
             return ValidationError("\n".join(messages))

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -1109,11 +1109,6 @@ def get_required_parameters_for_parameter_table(
     )
 
     # Parameters that are overridden via the condition table are not allowed
-    condition_targets = {
-        change.target_id
-        for cond in problem.conditions
-        for change in cond.changes
-    }
     parameter_ids -= condition_targets
 
     return parameter_ids

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -1010,6 +1010,9 @@ def get_valid_parameters_for_parameter_table(
     )
 
     # Add petab ids from mapping table if they are used for aliasing
+    # FIXME only add mapping.petab_id to allowed parameter IDs list if it
+    #       aliases an invalid PEtab ID? See
+    #       https://github.com/PEtab-dev/libpetab-python/pull/482#discussion_r3420762034
     for mapping in problem.mappings:
         if mapping.petab_id not in invalid:
             parameter_ids[mapping.petab_id] = None

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -1033,7 +1033,7 @@ def get_valid_parameters_for_parameter_table(
 
     # Add petab ids from mapping table if they are used for aliasing
     for mapping in problem.mappings:
-        if mapping.model_id:
+        if mapping.model_id and mapping.model_id in parameter_ids.keys():
             parameter_ids[mapping.petab_id] = None
             # An aliased model id is not a valid parameter id
             if mapping.model_id in parameter_ids:

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -555,9 +555,7 @@ class CheckExperimentConditionsExist(ValidationTask):
 class CheckAllParametersPresentInParameterTable(ValidationTask):
     """Ensure all required parameters are contained in the parameter table
     with no additional ones.
-
-    This also ensures that the mapping table petab ids
-    are used in the PEtab problem."""
+    """
 
     def run(self, problem: Problem) -> ValidationIssue | None:
         if problem.model is None:

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -554,8 +554,8 @@ class CheckExperimentConditionsExist(ValidationTask):
 
 class CheckAllParametersPresentInParameterTable(ValidationTask):
     """Ensure all required parameters are contained in the parameter table
-    with no additional ones. 
-    
+    with no additional ones.
+
     This also ensures that the mapping table petab ids
     are used in the PEtab problem."""
 
@@ -904,67 +904,68 @@ class CheckMappingTable(ValidationTask):
     """Validate the mapping table."""
 
     def run(self, problem: Problem) -> ValidationIssue | None:
+        # Mapping table is optional
+        if not problem.mappings:
+            return None
+
         messages = []
 
-        # Mapping table is optional
-        if problem.mappings:
-            # Check that each id, across both the petabEntityId and
-            # modelEntityId columns, occurs only once
-            must_be_unique_ids = []
-            for mapping in problem.mappings:
-                petab_id = getattr(mapping, "petab_id", None)
-                model_id = getattr(mapping, "model_id", None)
+        # Check that each id, across both the petabEntityId and
+        # modelEntityId columns, occurs only once
+        must_be_unique_ids = []
+        for mapping in problem.mappings:
+            petab_id = mapping.petab_id
+            model_id = mapping.model_id
 
-                if petab_id:
-                    must_be_unique_ids.append(petab_id)
-                # Duplicates for annotation-only rows (identity mappings)
-                # are permitted.
-                if petab_id == model_id:
-                    continue
-                if model_id:
-                    must_be_unique_ids.append(model_id)
+            if petab_id:
+                must_be_unique_ids.append(petab_id)
+            # Identity mappings are permitted for annotation
+            if petab_id == model_id:
+                continue
+            if model_id:
+                must_be_unique_ids.append(model_id)
 
-            non_unique_ids = sorted(
-                id_
-                for id_, count in Counter(must_be_unique_ids).items()
-                if count > 1
+        non_unique_ids = sorted(
+            id_
+            for id_, count in Counter(must_be_unique_ids).items()
+            if count > 1
+        )
+        if non_unique_ids:
+            return ValidationError(
+                f"Mapping table contains non-unique IDs: {non_unique_ids}."
             )
-            if non_unique_ids:
-                return ValidationError(
-                    f"Mapping table contains non-unique IDs: {non_unique_ids}."
-                )
 
-            # petabEntityId is not defined elsewhere in the PEtab problem
-            new_petab_ids = {
-                m.petab_id
-                for m in problem.mappings
-                # Ignore identity mappings used for annotation
-                if m.petab_id != m.model_id
-            }
-            old_petab_ids = (
-                {c.id for c in problem.conditions}
-                | {e.id for e in problem.experiments}
-                | {o.id for o in problem.observables}
+        # petabEntityId is not defined elsewhere in the PEtab problem
+        new_petab_ids = {
+            m.petab_id
+            for m in problem.mappings
+            # Ignore identity mappings used for annotation
+            if m.petab_id != m.model_id
+        }
+        old_petab_ids = (
+            {c.id for c in problem.conditions}
+            | {e.id for e in problem.experiments}
+            | {o.id for o in problem.observables}
+        )
+        if overdefined_ids := sorted(new_petab_ids & old_petab_ids):
+            messages.append(
+                f"PEtab IDs `{overdefined_ids}` are "
+                "defined in the mapping table but also defined through "
+                "other PEtab tables."
             )
-            if overdefined_ids := sorted(new_petab_ids & old_petab_ids):
-                messages.append(
-                    f"PEtab IDs `{overdefined_ids}` are "
-                    "defined in the mapping table but also defined through "
-                    "other PEtab tables."
-                )
 
-            for mapping in problem.mappings:
-                # petabEntityId not referenced in any model, if alias
-                for model in problem.models:
-                    if (
-                        mapping.petab_id != mapping.model_id
-                        and model.has_entity_with_id(mapping.petab_id)
-                    ):
-                        messages.append(
-                            f"`{mapping.petab_id}` is used in the mapping "
-                            "table and referenced directly in the model "
-                            f"`{model.model_id}`."
-                        )
+        for mapping in problem.mappings:
+            # petabEntityId not referenced in any model, if alias
+            for model in problem.models:
+                if (
+                    mapping.petab_id != mapping.model_id
+                    and model.has_entity_with_id(mapping.petab_id)
+                ):
+                    messages.append(
+                        f"`{mapping.petab_id}` is used in the mapping "
+                        "table and referenced directly in the model "
+                        f"`{model.model_id}`."
+                    )
 
         if messages:
             return ValidationError("\n".join(messages))
@@ -1069,7 +1070,6 @@ def get_required_parameters_for_parameter_table(
     # Start with mapping table petab ids
     parameter_ids = {m.petab_id for m in problem.mappings}
 
-    # Add parameters from measurement table, unless they are fixed parameters
     def append_overrides(overrides):
         parameter_ids.update(
             str(p) for p in overrides if isinstance(p, sp.Symbol)

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -954,9 +954,12 @@ class CheckMappingTable(ValidationTask):
                 )
 
             for mapping in problem.mappings:
-                # petabEntityId is not referenced in any model
+                # petabEntityId not referenced in any model, if alias
                 for model in problem.models:
-                    if model.has_entity_with_id(mapping.petab_id):
+                    if (
+                        mapping.petab_id != mapping.model_id
+                        and model.has_entity_with_id(mapping.petab_id)
+                    ):
                         messages.append(
                             f"`{mapping.petab_id}` is used in the mapping "
                             "table and referenced directly in the model "

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -44,6 +44,7 @@ __all__ = [
     "CheckPriorDistribution",
     "CheckUndefinedExperiments",
     "CheckInitialChangeSymbols",
+    "CheckMappingTable",
     "lint_problem",
     "default_validation_tasks",
 ]
@@ -551,7 +552,8 @@ class CheckExperimentConditionsExist(ValidationTask):
 
 class CheckAllParametersPresentInParameterTable(ValidationTask):
     """Ensure all required parameters are contained in the parameter table
-    with no additional ones."""
+    with no additional ones. This also ensures that the mapping table petab ids
+    are used in the PEtab problem."""
 
     def run(self, problem: Problem) -> ValidationIssue | None:
         if problem.model is None:
@@ -825,8 +827,8 @@ class CheckPriorDistribution(ValidationTask):
 
             if parameter.prior_distribution not in PRIOR_DISTRIBUTIONS:
                 messages.append(
-                    f"Prior distribution `{parameter.prior_distribution}' "
-                    f"for parameter `{parameter.id}' is not valid."
+                    f"Prior distribution `{parameter.prior_distribution}` "
+                    f"for parameter `{parameter.id}` is not valid."
                 )
                 continue
 
@@ -834,8 +836,8 @@ class CheckPriorDistribution(ValidationTask):
                 exp_num_par := self._num_pars[parameter.prior_distribution]
             ) != len(parameter.prior_parameters):
                 messages.append(
-                    f"Prior distribution `{parameter.prior_distribution}' "
-                    f"for parameter `{parameter.id}' requires "
+                    f"Prior distribution `{parameter.prior_distribution}` "
+                    f"for parameter `{parameter.id}` requires "
                     f"{exp_num_par} parameters, but got "
                     f"{len(parameter.prior_parameters)} "
                     f"({parameter.prior_parameters})."
@@ -848,8 +850,8 @@ class CheckPriorDistribution(ValidationTask):
                     _ = parameter.prior_dist.sample(1)
             except Exception as e:
                 messages.append(
-                    f"Prior parameters `{parameter.prior_parameters}' "
-                    f"for parameter `{parameter.id}' are invalid "
+                    f"Prior parameters `{parameter.prior_parameters}` "
+                    f"for parameter `{parameter.id}` are invalid "
                     f"(hint: {e})."
                 )
 
@@ -874,7 +876,7 @@ class CheckMeasurementModelId(ValidationTask):
                     continue
 
                 messages.append(
-                    f"Measurement `{measurement}' does not have a model ID, "
+                    f"Measurement `{measurement}` does not have a model ID, "
                     "but there are multiple models available. "
                     "Please specify the model ID in the measurement table."
                 )
@@ -882,11 +884,107 @@ class CheckMeasurementModelId(ValidationTask):
 
             if measurement.model_id not in available_models:
                 messages.append(
-                    f"Measurement `{measurement}' has model ID "
-                    f"`{measurement.model_id}' which does not match "
+                    f"Measurement `{measurement}` has model ID "
+                    f"`{measurement.model_id}` which does not match "
                     "any of the available models: "
                     f"{available_models}."
                 )
+
+        if messages:
+            return ValidationError("\n".join(messages))
+
+        return None
+
+
+class CheckMappingTable(ValidationTask):
+    """Validate the mapping table."""
+
+    def run(self, problem: Problem) -> ValidationIssue | None:
+        messages = []
+
+        # Mapping table is optional
+        if problem.mappings:
+            # Check that each id only occurs once
+            counter = Counter(
+                [
+                    getattr(mapping, attr)
+                    for mapping in problem.mappings
+                    for attr in ["petab_id", "model_id"]
+                    if getattr(mapping, attr)
+                ]
+            )
+            non_unique = {id_ for id_, count in counter.items() if count > 1}
+            if non_unique:
+                return ValidationError(
+                    f"Mapping table contains non-unique IDs: {non_unique}."
+                )
+
+            # petabEntityId is not defined elsewhere in the PEtab problem
+            petab_ids_mapping = {m.petab_id for m in problem.mappings}
+            defined_petab_ids = (
+                {c.id for c in problem.conditions}
+                | {e.id for e in problem.experiments}
+                | {o.id for o in problem.observables}
+            )
+            if petab_ids_mapping & defined_petab_ids:
+                messages.append(
+                    f"PEtab IDs `{petab_ids_mapping & defined_petab_ids}` are "
+                    "defined in the mapping table but also defined through "
+                    "other PEtab tables."
+                )
+            # Grab all symbols from condition table for later
+            condition_target_ids_values = {
+                sym
+                for cond in problem.conditions
+                for change in cond.changes
+                for sym in (
+                    change.target_value.free_symbols
+                    | change.target_id.free_symbols
+                )
+            }
+
+            for mapping in problem.mappings:
+                # petabEntityId is not referenced in any model
+                for model in problem.models:
+                    if model.has_entity_with_id(mapping.petab_id):
+                        messages.append(
+                            f"`{mapping.petab_id}` is used in the mapping "
+                            "table and referenced directly in the model "
+                            f"`{model.model_id}`."
+                        )
+
+                # modelEntityId can be empty
+                if mapping.model_id:
+                    # model_id is not in petab problem
+                    if mapping.model_id in defined_petab_ids:
+                        messages.append(
+                            f"PEtab ID `{mapping.model_id}` mirrors the "
+                            "model entity ID referenced in the mapping table."
+                        )
+                    if mapping.model_id in condition_target_ids_values:
+                        messages.append(
+                            f"Identifier `{mapping.model_id}` is mapped to a "
+                            "PEtab ID in the mapping table, but also directly "
+                            "used in the conditions table."
+                        )
+                    for observable_formula in [
+                        o.formula for o in problem.observables
+                    ]:
+                        if mapping.model_id in observable_formula.free_symbols:
+                            messages.append(
+                                f"Identifier `{mapping.model_id}` is mapped "
+                                "to a PEtab ID in the mapping table, but also "
+                                "directly used in an observable formula."
+                            )
+                    for obs_noise_formula in [
+                        o.noise_formula for o in problem.observables
+                    ]:
+                        if mapping.model_id in obs_noise_formula.free_symbols:
+                            messages.append(
+                                f"Identifier `{mapping.model_id}` is mapped "
+                                "to a PEtab ID in the mapping table, but also "
+                                "directly used in a noise formula."
+                            )
 
         if messages:
             return ValidationError("\n".join(messages))
@@ -933,9 +1031,13 @@ def get_valid_parameters_for_parameter_table(
         if p not in invalid
     )
 
+    # Add petab ids from mapping table if they are used for aliasing
     for mapping in problem.mappings:
-        if mapping.model_id and mapping.model_id in parameter_ids.keys():
+        if mapping.model_id:
             parameter_ids[mapping.petab_id] = None
+            # An aliased model id is not a valid parameter id
+            if mapping.model_id in parameter_ids:
+                del parameter_ids[mapping.model_id]
 
     # add output parameters from observable table
     output_parameters = problem.get_output_parameters()
@@ -977,20 +1079,13 @@ def get_required_parameters_for_parameter_table(
         measurement table as well as all parametric condition table overrides
         that are not defined in the model.
     """
-    parameter_ids = set()
-    condition_targets = {
-        change.target_id
-        for cond in problem.conditions
-        for change in cond.changes
-    }
+    # Start with mapping table petab ids
+    parameter_ids = {m.petab_id for m in problem.mappings}
 
     # Add parameters from measurement table, unless they are fixed parameters
     def append_overrides(overrides):
         parameter_ids.update(
-            str_p
-            for p in overrides
-            if isinstance(p, sp.Symbol)
-            and (str_p := str(p)) not in condition_targets
+            str(p) for p in overrides if isinstance(p, sp.Symbol)
         )
 
     for m in problem.measurements:
@@ -1033,7 +1128,12 @@ def get_required_parameters_for_parameter_table(
         if not problem.model.has_entity_with_id(str(p))
     )
 
-    # parameters that are overridden via the condition table are not allowed
+    # Parameters that are overridden via the condition table are not allowed
+    condition_targets = {
+        change.target_id
+        for cond in problem.conditions
+        for change in cond.changes
+    }
     parameter_ids -= condition_targets
 
     return parameter_ids
@@ -1090,5 +1190,5 @@ default_validation_tasks = [
     CheckUnusedConditions(),
     CheckPriorDistribution(),
     CheckInitialChangeSymbols(),
-    # TODO validate mapping table
+    CheckMappingTable(),
 ]

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -1010,15 +1010,16 @@ def get_valid_parameters_for_parameter_table(
     )
 
     # Add petab ids from mapping table if they are used for aliasing
-    # FIXME only add mapping.petab_id to allowed parameter IDs list if it
-    #       aliases an invalid PEtab ID? See
-    #       https://github.com/PEtab-dev/libpetab-python/pull/482#discussion_r3420762034
     for mapping in problem.mappings:
-        if mapping.model_id and mapping.model_id in parameter_ids.keys():
+        if mapping.petab_id not in invalid:
             parameter_ids[mapping.petab_id] = None
-            # An aliased model id is not a valid parameter id
-            if mapping.model_id in parameter_ids:
-                del parameter_ids[mapping.model_id]
+        # An aliased model id is not a valid parameter id
+        if (
+            mapping.model_id
+            and mapping.model_id != mapping.petab_id
+            and mapping.model_id in parameter_ids
+        ):
+            del parameter_ids[mapping.model_id]
 
     # add output parameters from observable table
     output_parameters = problem.get_output_parameters()

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -1012,20 +1012,9 @@ def get_valid_parameters_for_parameter_table(
         if p not in invalid
     )
 
-    # Add petab ids from mapping table if they are used for aliasing
-    # FIXME only add mapping.petab_id to allowed parameter IDs list if it
-    #       aliases an invalid PEtab ID? See
-    #       https://github.com/PEtab-dev/libpetab-python/pull/482#discussion_r3420762034
     for mapping in problem.mappings:
-        if mapping.petab_id not in invalid:
+        if mapping.model_id and mapping.model_id in parameter_ids.keys():
             parameter_ids[mapping.petab_id] = None
-        # An aliased model id is not a valid parameter id
-        if (
-            mapping.model_id
-            and mapping.model_id != mapping.petab_id
-            and mapping.model_id in parameter_ids
-        ):
-            del parameter_ids[mapping.model_id]
 
     # add output parameters from observable table
     output_parameters = problem.get_output_parameters()
@@ -1067,8 +1056,12 @@ def get_required_parameters_for_parameter_table(
         measurement table as well as all parametric condition table overrides
         that are not defined in the model.
     """
-    # Start with mapping table petab ids
-    parameter_ids = {m.petab_id for m in problem.mappings}
+    parameter_ids = set()
+    condition_targets = {
+        change.target_id
+        for cond in problem.conditions
+        for change in cond.changes
+    }
 
     def append_overrides(overrides):
         parameter_ids.update(

--- a/tests/v2/test_core.py
+++ b/tests/v2/test_core.py
@@ -181,7 +181,7 @@ def test_measurments():
 
 
 def test_observable():
-    Observable(id="obs1", formula=x + y)
+    Observable(id="obs1", formula=x + y, noiseFormula=1)
     Observable(id="obs1", formula="x + y", noise_formula="x + y")
     Observable(id="obs1", formula=1, noise_formula=2)
     Observable(
@@ -198,9 +198,17 @@ def test_observable():
         observable_parameters=[sp.Symbol("p1")],
         noise_parameters=[sp.Symbol("n1")],
     )
-    assert Observable(id="obs1", formula="x + y", non_petab=1).non_petab == 1
+    assert (
+        Observable(
+            id="obs1",
+            formula="x + y",
+            noise_formula="x + y",
+            non_petab=1,
+        ).non_petab
+        == 1
+    )
 
-    o = Observable(id="obs1", formula=x + y)
+    o = Observable(id="obs1", formula=x + y, noise_formula=1)
     assert o.observable_placeholders == []
     assert o.noise_placeholders == []
 
@@ -492,14 +500,14 @@ def test_modify_problem():
         problem.condition_df, exp_condition_df, check_dtype=False
     )
 
-    problem.add_observable("observable1", "1")
+    problem.add_observable("observable1", "1", noise_formula=1)
     problem.add_observable("observable2", "2", noise_formula=2.2)
 
     exp_observable_df = pd.DataFrame(
         data={
             OBSERVABLE_ID: ["observable1", "observable2"],
             OBSERVABLE_FORMULA: [1, 2],
-            NOISE_FORMULA: [np.nan, 2.2],
+            NOISE_FORMULA: [1, 2.2],
         }
     ).set_index([OBSERVABLE_ID])
     assert_frame_equal(

--- a/tests/v2/test_lint.py
+++ b/tests/v2/test_lint.py
@@ -2,8 +2,11 @@
 
 from copy import deepcopy
 
+from petabtests import DEFAULT_PYSB_FILE
+
 from petab.v2 import Problem
 from petab.v2.lint import *
+from petab.v2.models.pysb_model import PySBModel
 from petab.v2.models.sbml_model import SbmlModel
 
 
@@ -43,7 +46,7 @@ def test_invalid_model_id_in_measurements():
     """Test that measurements with an invalid model ID are caught."""
     problem = Problem()
     problem.models.append(SbmlModel.from_antimony("p1 = 1", model_id="model1"))
-    problem.add_observable("obs1", "A")
+    problem.add_observable("obs1", "A", 1)
     problem.add_measurement("obs1", experiment_id="e1", time=0, measurement=1)
 
     check = CheckMeasurementModelId()
@@ -70,7 +73,7 @@ def test_undefined_experiment_id_in_measurements():
     """Test that measurements with an undefined experiment ID are caught."""
     problem = Problem()
     problem.add_experiment("e1", 0, "c1")
-    problem.add_observable("obs1", "A")
+    problem.add_observable("obs1", "A", 1)
     problem.add_measurement("obs1", experiment_id="e1", time=0, measurement=1)
 
     check = CheckUndefinedExperiments()
@@ -107,3 +110,48 @@ def test_validate_initial_change_symbols():
     problem.parameter_tables[0].parameters.remove(problem["p2"])
     assert (error := check.run(problem)) is not None
     assert "contains additional symbols: {'p2'}" in error.message
+
+
+def test_check_mapping_table():
+    """Test checks related to the mapping table."""
+    problem = Problem()
+    # PySB model from PEtab test suite
+    problem.model = PySBModel.from_file(DEFAULT_PYSB_FILE)
+    problem.add_mapping(
+        petab_id="A_comp",
+        model_id="A_() ** compartment",
+        name=None,
+    )
+    problem.add_parameter(
+        "A_comp",
+        estimate=True,
+        nominal_value=2,
+        lb=0,
+        ub=10,
+    )
+
+    check = CheckMappingTable()
+    assert check.run(problem) is None
+
+    check = CheckAllParametersPresentInParameterTable()
+    assert check.run(problem) is None
+
+    # add a petab id without model id but with name for annotation
+    problem.add_mapping(petab_id="p2", model_id=None, name="Parameter 2")
+    problem.add_parameter("p2", estimate=True, nominal_value=1, lb=0, ub=10)
+
+    check = CheckMappingTable()
+    assert check.run(problem) is None
+
+    # Invalid: petabEntityId is referenced in the model
+    problem.mapping_tables = []
+    problem.add_mapping(
+        petab_id="a0",
+        model_id="A_() ** compartment",
+        name=None,
+    )
+    assert (error := check.run(problem)) is not None
+    assert (
+        "`a0` is used in the mapping table and referenced directly"
+        in error.message
+    )

--- a/tests/v2/test_lint.py
+++ b/tests/v2/test_lint.py
@@ -2,11 +2,8 @@
 
 from copy import deepcopy
 
-from petabtests import DEFAULT_PYSB_FILE
-
 from petab.v2 import Problem
 from petab.v2.lint import *
-from petab.v2.models.pysb_model import PySBModel
 from petab.v2.models.sbml_model import SbmlModel
 
 
@@ -116,14 +113,14 @@ def test_check_mapping_table():
     """Test checks related to the mapping table."""
     problem = Problem()
     # PySB model from PEtab test suite
-    problem.model = PySBModel.from_file(DEFAULT_PYSB_FILE)
+    problem.model = SbmlModel.from_antimony("a.mean = 1")
     problem.add_mapping(
-        petab_id="A_comp",
-        model_id="A_() ** compartment",
+        petab_id="a_m",
+        model_id="a.mean",
         name=None,
     )
     problem.add_parameter(
-        "A_comp",
+        "a_m",
         estimate=True,
         nominal_value=2,
         lb=0,
@@ -144,14 +141,9 @@ def test_check_mapping_table():
     assert check.run(problem) is None
 
     # Invalid: petabEntityId is referenced in the model
-    problem.mapping_tables = []
-    problem.add_mapping(
-        petab_id="a0",
-        model_id="A_() ** compartment",
-        name=None,
-    )
+    problem.model = SbmlModel.from_antimony("a.mean = 1; a_m = 2")
     assert (error := check.run(problem)) is not None
     assert (
-        "`a0` is used in the mapping table and referenced directly"
+        "`a_m` is used in the mapping table and referenced directly"
         in error.message
     )

--- a/tests/v2/test_lint.py
+++ b/tests/v2/test_lint.py
@@ -2,9 +2,21 @@
 
 from copy import deepcopy
 
+import pysb
+import pytest
+
 from petab.v2 import Problem
 from petab.v2.lint import *
+from petab.v2.models.pysb_model import PySBModel
 from petab.v2.models.sbml_model import SbmlModel
+
+
+@pytest.fixture
+def uses_pysb():
+    """Cleanup PySB auto-exported symbols before and after test"""
+    pysb.SelfExporter.cleanup()
+    yield ()
+    pysb.SelfExporter.cleanup()
 
 
 def test_check_experiments():
@@ -109,18 +121,21 @@ def test_validate_initial_change_symbols():
     assert "contains additional symbols: {'p2'}" in error.message
 
 
-def test_check_mapping_table():
+def test_check_mapping_table(uses_pysb):
     """Test checks related to the mapping table."""
     problem = Problem()
-    # FIXME see https://github.com/PEtab-dev/libpetab-python/pull/482#discussion_r3431330125
-    problem.model = SbmlModel.from_antimony("a.mean = 1")
+    # PySB model with monomer 'A' having site 'b'; the model entity
+    # 'A.b' is PEtab-incompatible (dots not allowed) and requires mapping.
+    pysb_model = pysb.Model("test_model")
+    pysb.Monomer("A", ["b"])
+    problem.model = PySBModel(model=pysb_model, model_id="test_model")
     problem.add_mapping(
-        petab_id="a_m",
-        model_id="a.mean",
+        petab_id="a_b",
+        model_id="A.b",
         name=None,
     )
     problem.add_parameter(
-        "a_m",
+        "a_b",
         estimate=True,
         nominal_value=2,
         lb=0,
@@ -141,9 +156,15 @@ def test_check_mapping_table():
     assert check.run(problem) is None
 
     # Invalid: petabEntityId is referenced in the model
-    problem.model = SbmlModel.from_antimony("a.mean = 1; a_m = 2")
+    pysb.SelfExporter.cleanup()
+    pysb_model_invalid = pysb.Model("test_model_invalid")
+    pysb.Monomer("A", ["b"])
+    pysb.Parameter("a_b", 2)
+    problem.model = PySBModel(
+        model=pysb_model_invalid, model_id="test_model_invalid"
+    )
     assert (error := check.run(problem)) is not None
     assert (
-        "`a_m` is used in the mapping table and referenced directly"
+        "`a_b` is used in the mapping table and referenced directly"
         in error.message
     )

--- a/tests/v2/test_lint.py
+++ b/tests/v2/test_lint.py
@@ -112,7 +112,7 @@ def test_validate_initial_change_symbols():
 def test_check_mapping_table():
     """Test checks related to the mapping table."""
     problem = Problem()
-    # PySB model from PEtab test suite
+    # FIXME see https://github.com/PEtab-dev/libpetab-python/pull/482#discussion_r3431330125
     problem.model = SbmlModel.from_antimony("a.mean = 1")
     problem.add_mapping(
         petab_id="a_m",

--- a/tests/v2/test_lint.py
+++ b/tests/v2/test_lint.py
@@ -124,23 +124,14 @@ def test_validate_initial_change_symbols():
 def test_check_mapping_table(uses_pysb):
     """Test checks related to the mapping table."""
     problem = Problem()
-    # PySB model with monomer 'A' having site 'b'; the model entity
-    # 'A.b' is PEtab-incompatible (dots not allowed) and requires mapping.
+
+    # PySB model with a compartment and a monomer, and mapping of model entity
+    # to a valid PEtab id
     pysb_model = pysb.Model("test_model")
-    pysb.Monomer("A", ["b"])
+    pysb.Monomer("A_")
+    pysb.Initial(A_() ** pysb.Compartment("C"), pysb.Parameter("a0", 1))
     problem.model = PySBModel(model=pysb_model, model_id="test_model")
-    problem.add_mapping(
-        petab_id="a_b",
-        model_id="A.b",
-        name=None,
-    )
-    problem.add_parameter(
-        "a_b",
-        estimate=True,
-        nominal_value=2,
-        lb=0,
-        ub=10,
-    )
+    problem.add_mapping("A", "A_() ** C")
 
     check = CheckMappingTable()
     assert check.run(problem) is None
@@ -158,13 +149,13 @@ def test_check_mapping_table(uses_pysb):
     # Invalid: petabEntityId is referenced in the model
     pysb.SelfExporter.cleanup()
     pysb_model_invalid = pysb.Model("test_model_invalid")
-    pysb.Monomer("A", ["b"])
-    pysb.Parameter("a_b", 2)
+    pysb.Monomer("A_")
+    pysb.Initial(A_() ** pysb.Compartment("C"), pysb.Parameter("A", 1))
     problem.model = PySBModel(
         model=pysb_model_invalid, model_id="test_model_invalid"
     )
     assert (error := check.run(problem)) is not None
     assert (
-        "`a_b` is used in the mapping table and referenced directly"
+        "`A` is used in the mapping table and referenced directly"
         in error.message
     )


### PR DESCRIPTION
- core: Update Fields/Annotations to match the PEtab v2 docs
- add a lint check for the mapping table
- Change the logic in `petab.v2.lint.get_valid_parameters_for_parameter_table`: add mapping table `petabEntityId` regardless of whether the corresponding `modelEntityId` would be valid (was L937->L1036)
- add a test for mapping table linting