### PR TITLE
fix: declare scipy runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "jsonschema",
     "antlr4-python3-runtime==4.13.1",
     "pydantic>=2.10",
+    "scipy",
 ]
 license = "MIT"
 authors = [
@@ -38,7 +39,6 @@ tests = [
     "pysb",
     "pytest",
     "pytest-cov",
-    "scipy",
 ]
 quality = [
     "pre-commit",


### PR DESCRIPTION
Fixes #483.

`petab.v2` imports and re-exports `petab.v1.distributions` at module import time, and `petab.v1.distributions` imports `scipy.stats` at the top level. Because `scipy` was only present in extras, a clean install with the core dependencies could still fail on `import petab.v2` with `ModuleNotFoundError: No module named 'scipy'`.

This moves `scipy` into the core project dependencies so the currently exported distribution API is installed with the package. I removed the duplicate `tests` extra entry; the `vis` extra still keeps its scipy entry because that extra expresses the visualization dependency set.

Verification:
- Reproduced before the change in a venv with all core dependencies except scipy installed: `python -c "import petab.v2"` failed at `petab.v1.distributions` importing `scipy.stats`.
- After the change, `pip install -e .` installs metadata containing core `scipy`, and `python -c "import petab.v2"` succeeds.
- `python -m pytest tests/v1/test_distributions.py`: 19 passed.
- `python -m build --wheel`: succeeded.

I also tried `tests/v2/test_core.py tests/v1/test_distributions.py`; the distributions tests passed, while several v2 tests failed because this local environment could not fetch remote GitHub fixtures and did not install the `antimony` test extra. Those failures are unrelated to the dependency metadata change.