### PR TITLE
Fix PetabStrPrinter for non-integer rational exponents

### DIFF
--- a/petab/v1/math/printer.py
+++ b/petab/v1/math/printer.py
@@ -41,9 +41,9 @@ class PetabStrPrinter(StrPrinter):
         str_exp = self._print(exp)
         if not base.is_Atom:
             str_base = f"({str_base})"
-        # A non-integer Rational exponent (e.g. sqrt -> 1/2) is an Atom but prints as the
-        # multi-token "1/2", so without parentheses "x ^ 1/2" re-parses as (x^1)/2. The
-        # `not exp.is_Atom` check above (#421) misses it; parenthesize it explicitly.
+        # A non-integer Rational exponent (e.g. sqrt -> 1/2) is an Atom but
+        # prints as the multi-token "1/2", so without parentheses "x ^ 1/2"
+        # re-parses as (x^1)/2. Parenthesize it explicitly.
         if not exp.is_Atom or (exp.is_Rational and not exp.is_Integer):
             str_exp = f"({str_exp})"
         return f"{str_base} ^ {str_exp}"

--- a/petab/v1/math/printer.py
+++ b/petab/v1/math/printer.py
@@ -41,7 +41,10 @@ class PetabStrPrinter(StrPrinter):
         str_exp = self._print(exp)
         if not base.is_Atom:
             str_base = f"({str_base})"
-        if not exp.is_Atom:
+        # A non-integer Rational exponent (e.g. sqrt -> 1/2) is an Atom but prints as the
+        # multi-token "1/2", so without parentheses "x ^ 1/2" re-parses as (x^1)/2. The
+        # `not exp.is_Atom` check above (#421) misses it; parenthesize it explicitly.
+        if not exp.is_Atom or (exp.is_Rational and not exp.is_Integer):
             str_exp = f"({str_exp})"
         return f"{str_base} ^ {str_exp}"
 

--- a/tests/v1/math/test_math.py
+++ b/tests/v1/math/test_math.py
@@ -43,8 +43,8 @@ def test_printer():
     assert petab_math_str(BooleanTrue()) == "true"
     assert petab_math_str(BooleanFalse()) == "false"
     assert petab_math_str((a + b) ** (c + d)) == "(a + b) ^ (c + d)"
-    # A non-integer rational exponent must be parenthesized, else "a ^ 1/2" re-parses as
-    # (a^1)/2 (i.e. sqrt(a) would round-trip to a/2). See #421 for the base/exponent case.
+    # A non-integer rational exponent must be parenthesized, else "a ^ 1/2"
+    # re-parses as (a^1)/2 (i.e. sqrt(a) would round-trip to a/2).
     assert petab_math_str(sp.sqrt(a)) == "a ^ (1/2)"
     assert petab_math_str(a ** sp.Rational(2, 3)) == "a ^ (2/3)"
 

--- a/tests/v1/math/test_math.py
+++ b/tests/v1/math/test_math.py
@@ -43,6 +43,10 @@ def test_printer():
     assert petab_math_str(BooleanTrue()) == "true"
     assert petab_math_str(BooleanFalse()) == "false"
     assert petab_math_str((a + b) ** (c + d)) == "(a + b) ^ (c + d)"
+    # A non-integer rational exponent must be parenthesized, else "a ^ 1/2" re-parses as
+    # (a^1)/2 (i.e. sqrt(a) would round-trip to a/2). See #421 for the base/exponent case.
+    assert petab_math_str(sp.sqrt(a)) == "a ^ (1/2)"
+    assert petab_math_str(a ** sp.Rational(2, 3)) == "a ^ (2/3)"
 
 
 def read_cases():


### PR DESCRIPTION
`petab_math_str(sympify_petab(x))` is not the identity for square roots and other non-integer rational exponents. For example, `petab_math_str(sqrt(a))` returns `a ^ 1/2`, which `sympify_petab` re-parses as `(a^1)/2 = a/2`. This is a silent mangling of the expression.

The cause is that a non-integer `Rational` exponent, such as `1/2`, is a sympy `Atom` but prints as the multi-token string `1/2`, so the `not exp.is_Atom` guard added in #421 does not parenthesize it. Since `^` binds tighter than `/`, the unparenthesized `a ^ 1/2` then parses as `(a^1)/2`.

This fix parenthesizes a non-integer rational exponent explicitly, so `petab_math_str(sqrt(a)) == "a ^ (1/2)"`, which re-parses correctly. Integer powers and the non-atomic base/exponent cases from #421 are unchanged.
