### PR TITLE
CI: Fix installation of benchmark_models_petab

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ description =
 extras = tests,reports,combine,vis
 deps=
   git+https://github.com/PEtab-dev/petab_test_suite@main
-  git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python
+  -e git+https://github.com/Benchmarking-Initiative/Benchmark-Models-PEtab.git@master\#subdirectory=src/python&egg=benchmark_models_petab
 
 commands =
   python -m pip install sympy>=1.12.1


### PR DESCRIPTION
Building the wheel for benchmark_models_petab fails with current setuptools. Symlink issues. Use editable installation.