### PR TITLE
Allow for condition ids to be defined inside array files (SciML problems only)

### DIFF
--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -249,6 +249,12 @@ class ExperimentsToSbmlConverter:
             #  single-period experiments.
             if i_period == 0:
                 exp_ind_id = self.get_experiment_indicator(experiment.id)
+                # If condition ids are set by array data, skip as importers handle this
+                if set(period.condition_ids).issubset(
+                    self._new_problem._get_array_data_condition_ids()
+                ):
+                    continue
+
                 for change in self._new_problem.get_changes_for_period(period):
                     period0_assignments.setdefault(
                         change.target_id, []

--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -249,11 +249,13 @@ class ExperimentsToSbmlConverter:
             #  single-period experiments.
             if i_period == 0:
                 exp_ind_id = self.get_experiment_indicator(experiment.id)
-                # If condition ids are set by array data, skip as importers handle this
-                if set(period.condition_ids).issubset(
-                    self._new_problem._get_array_data_condition_ids()
-                ):
-                    continue
+                # Skip if condition ids are set by array data
+                # importers handle this
+                if self._new_problem.extensions.sciml:
+                    if set(period.condition_ids).issubset(
+                        self._new_problem.extensions.sciml._get_array_data_condition_ids()
+                    ):
+                        continue
 
                 for change in self._new_problem.get_changes_for_period(period):
                     period0_assignments.setdefault(

--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -88,6 +88,11 @@ class ExperimentsToSbmlConverter:
         self._model: libsbml.Model = self._new_problem.model.sbml_model
         self._preeq_indicator = self.PREEQ_INDICATOR
 
+        sciml = self._new_problem.extensions.sciml
+        self._array_data_condition_ids = (
+            sciml._get_array_data_condition_ids() if sciml else set()
+        )
+
         # The maximum event priority that was found in the unprocessed model.
         self._max_event_priority = None
         # The priority that will be used for the PEtab events.
@@ -251,11 +256,10 @@ class ExperimentsToSbmlConverter:
                 exp_ind_id = self.get_experiment_indicator(experiment.id)
                 # Skip if condition ids are set by array data
                 # importers handle this
-                if self._new_problem.extensions.sciml:
-                    if set(period.condition_ids).issubset(
-                        self._new_problem.extensions.sciml._get_array_data_condition_ids()
-                    ):
-                        continue
+                if self._array_data_condition_ids and set(
+                    period.condition_ids
+                ).issubset(self._array_data_condition_ids):
+                    continue
 
                 for change in self._new_problem.get_changes_for_period(period):
                     period0_assignments.setdefault(

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -2288,6 +2288,14 @@ ExperimentPeriod(time=2.0, condition_ids=['condition2a', 'condition2b'])])
             Experiment(id=id_, periods=periods)
         )
 
+    def _get_array_data_condition_ids(self) -> set[str]:
+        """Get the set of condition IDs that are referenced in the array data files."""
+        condition_ids = set()
+        for array_data in self.array_data_files:
+            for input in array_data.inputs.values():
+                condition_ids.update(input.keys())
+        return condition_ids
+
     def __iadd__(self, other):
         """Add Observable, Parameter, Measurement, Condition, or Experiment"""
         from .core import (

--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -2288,14 +2288,6 @@ ExperimentPeriod(time=2.0, condition_ids=['condition2a', 'condition2b'])])
             Experiment(id=id_, periods=periods)
         )
 
-    def _get_array_data_condition_ids(self) -> set[str]:
-        """Get the set of condition IDs that are referenced in the array data files."""
-        condition_ids = set()
-        for array_data in self.array_data_files:
-            for input in array_data.inputs.values():
-                condition_ids.update(input.keys())
-        return condition_ids
-
     def __iadd__(self, other):
         """Add Observable, Parameter, Measurement, Condition, or Experiment"""
         from .core import (

--- a/petab/v2/extensions/sciml.py
+++ b/petab/v2/extensions/sciml.py
@@ -303,3 +303,12 @@ class SciMLExt:
             hybridization_tables=hybridization_tables,
             array_data_files=array_data_files,
         )
+
+    def _get_array_data_condition_ids(self) -> set[str]:
+        """Get the set of condition IDs that are referenced in the array data
+        files."""
+        condition_ids = set()
+        for array_data in self.array_data_files:
+            for input in array_data.inputs.values():
+                condition_ids.update(input.keys())
+        return condition_ids

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -532,10 +532,10 @@ class CheckExperimentConditionsExist(ValidationTask):
     def run(self, problem: Problem) -> ValidationIssue | None:
         messages = []
         available_conditions = {c.id for c in problem.conditions}
-        if problem.array_data_files:
+        if problem.extensions.sciml:
             available_conditions |= {
                 key
-                for array_data in problem.array_data_files
+                for array_data in problem.extensions.sciml.array_data_files
                 for input_array in array_data.inputs.values()
                 for key in input_array.keys()
             }

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -532,6 +532,13 @@ class CheckExperimentConditionsExist(ValidationTask):
     def run(self, problem: Problem) -> ValidationIssue | None:
         messages = []
         available_conditions = {c.id for c in problem.conditions}
+        if problem.array_data_files:
+            available_conditions |= {
+                key
+                for array_data in problem.array_data_files
+                for input_array in array_data.inputs.values()
+                for key in input_array.keys()
+            }
         for experiment in problem.experiments:
             missing_conditions = (
                 set(
@@ -972,6 +979,14 @@ class CheckMappingTable(ValidationTask):
         return None
 
 
+class CheckExperimentalConditionsDefined(ValidationTask):
+    """A task to check that all conditions referenced by the experiments
+    are defined."""
+
+    def run(self, problem: Problem) -> ValidationIssue | None:
+        return None
+
+
 def get_valid_parameters_for_parameter_table(
     problem: Problem,
 ) -> set[str]:
@@ -1189,4 +1204,5 @@ from ..v2.extensions.sciml_lint import CheckHybridizationTable  # noqa: E402
 #: Validation tasks that should be run PEtab SciML problems
 sciml_validation_tasks = default_validation_tasks + [
     CheckHybridizationTable(),
+    CheckExperimentalConditionsDefined(),
 ]

--- a/petab/v2/lint.py
+++ b/petab/v2/lint.py
@@ -979,14 +979,6 @@ class CheckMappingTable(ValidationTask):
         return None
 
 
-class CheckExperimentalConditionsDefined(ValidationTask):
-    """A task to check that all conditions referenced by the experiments
-    are defined."""
-
-    def run(self, problem: Problem) -> ValidationIssue | None:
-        return None
-
-
 def get_valid_parameters_for_parameter_table(
     problem: Problem,
 ) -> set[str]:
@@ -1204,5 +1196,4 @@ from ..v2.extensions.sciml_lint import CheckHybridizationTable  # noqa: E402
 #: Validation tasks that should be run PEtab SciML problems
 sciml_validation_tasks = default_validation_tasks + [
     CheckHybridizationTable(),
-    CheckExperimentalConditionsDefined(),
 ]

--- a/tests/v2/test_sciml.py
+++ b/tests/v2/test_sciml.py
@@ -48,9 +48,9 @@ def _get_test_problem():
       -> B; gamma_;
     end
     """)
-    problem.add_experiment("e1", 0, "")
+    problem.add_experiment("e1", 0, "cond1")
     problem.add_mapping("net1_input1", "net1.inputs[0][0]")
-    problem.add_mapping("net1_input2", "net1.inputs[0][1]")
+    problem.add_mapping("net1_input2", "net1.inputs[1]")
     problem.add_mapping("net1_output1", "net1.outputs[0][0]")
     problem.add_mapping("net1_ps", "net1.parameters")
     problem.add_measurement("B_obs", time=1, measurement=1, experiment_id="e1")
@@ -62,7 +62,7 @@ def _get_test_problem():
         "net1_ps", estimate=True, lb=-np.inf, ub=np.inf, nominal_value="array"
     )
     problem.extensions.sciml.add_hybridization("net1_input1", "A")
-    problem.extensions.sciml.add_hybridization("net1_input2", "B")
+    problem.extensions.sciml.add_hybridization("net1_input2", "array")
     problem.extensions.sciml.add_hybridization("gamma_", "net1_output1")
     problem.extensions.sciml.add_neural_network_from_dict(
         "net1",
@@ -106,7 +106,11 @@ def _get_test_problem():
     problem.extensions.sciml.add_array_data_from_dict(
         {
             "metadata": {"pytorch_format": True},
-            "inputs": {},
+            "inputs": {
+                "net1_input2": {
+                    "cond1": np.random.randn(2),
+                }
+            },
             "parameters": {
                 "net1": {
                     "layer1": {


### PR DESCRIPTION
Condition specific inputs to neural networks can be provided as array files for SciML problems. For these condition specific inputs, condition ids referenced in the experiments table need to be defined in the array files rather than the conditions table. https://petab-sciml.readthedocs.io/latest/format.html#inputs

This PR adds:

- a check for condition ids in array files to the `CheckExperimentConditionsExist` validation task
- a workaround for the array-defined condition ids in `_convert_experiment` (AMICI's sciml support handles condition specific array inputs elsewhere)