### PR TITLE
Fix missing return in v1v2_observable_df noise distribution merge

### DIFF
--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -416,6 +416,8 @@ def v1v2_observable_df(observable_df: pd.DataFrame) -> pd.DataFrame:
                     f" is not supported in PEtab v2."
                 )
 
+            return new_dist
+
         df[v2.C.NOISE_DISTRIBUTION] = df.apply(update_noise_dist, axis=1)
         df.drop(columns=[v1.C.OBSERVABLE_TRANSFORMATION], inplace=True)
 

--- a/petab/v2/petab1to2.py
+++ b/petab/v2/petab1to2.py
@@ -389,7 +389,7 @@ def v1v2_observable_df(observable_df: pd.DataFrame) -> pd.DataFrame:
             df[v1.C.NOISE_DISTRIBUTION] = v1.C.NORMAL
 
         # merge observableTransformation into noiseDistribution
-        def update_noise_dist(row):
+        def get_noise_dist(row):
             dist = row.get(v1.C.NOISE_DISTRIBUTION)
             trans = row.get(v1.C.OBSERVABLE_TRANSFORMATION)
 
@@ -418,7 +418,7 @@ def v1v2_observable_df(observable_df: pd.DataFrame) -> pd.DataFrame:
 
             return new_dist
 
-        df[v2.C.NOISE_DISTRIBUTION] = df.apply(update_noise_dist, axis=1)
+        df[v2.C.NOISE_DISTRIBUTION] = df.apply(get_noise_dist, axis=1)
         df.drop(columns=[v1.C.OBSERVABLE_TRANSFORMATION], inplace=True)
 
     def extract_placeholders(row: pd.Series, type_: str) -> str:

--- a/tests/v2/test_conversion.py
+++ b/tests/v2/test_conversion.py
@@ -1,9 +1,33 @@
 import logging
 
+import pandas as pd
 import pytest
 
+import petab.v1 as v1
+import petab.v2 as v2
 from petab.v2 import Problem
-from petab.v2.petab1to2 import petab1to2
+from petab.v2.petab1to2 import petab1to2, v1v2_observable_df
+
+
+def test_v1v2_observable_df_noise_distribution():
+    """Test that noiseDistribution is correctly merged with
+    observableTransformation."""
+    observable_df = pd.DataFrame(
+        data={
+            v1.C.OBSERVABLE_ID: ["obs1", "obs2"],
+            v1.C.OBSERVABLE_FORMULA: ["a", "b"],
+            v1.C.NOISE_FORMULA: ["1", "1"],
+            v1.C.OBSERVABLE_TRANSFORMATION: [v1.C.LIN, v1.C.LOG],
+            v1.C.NOISE_DISTRIBUTION: [v1.C.NORMAL, v1.C.NORMAL],
+        }
+    ).set_index(v1.C.OBSERVABLE_ID)
+
+    new_df = v1v2_observable_df(observable_df)
+
+    assert list(new_df[v2.C.NOISE_DISTRIBUTION]) == [
+        v2.C.NORMAL,
+        v2.C.LOG_NORMAL,
+    ]
 
 
 def test_petab1to2_remote():


### PR DESCRIPTION
update_noise_dist lacked a return statement, so the merged noiseDistribution column was always NaN after petab1to2 conversion.