### PR TITLE
CI: Fix flaky remote file access

### DIFF
--- a/tests/v1/test_petab.py
+++ b/tests/v1/test_petab.py
@@ -783,8 +783,8 @@ def test_to_files(petab_problem):  # pylint: disable=W0621
 def test_load_remote():
     """Test loading remote files"""
     yaml_url = (
-        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
-        "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
+        "https://cdn.jsdelivr.net/gh/PEtab-dev/petab_test_suite"
+        "@main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
     )
     petab_problem = petab.Problem.from_yaml(yaml_url)
 

--- a/tests/v1/test_yaml.py
+++ b/tests/v1/test_yaml.py
@@ -102,8 +102,8 @@ def test_get_path_prefix():
 
 def test_validate_remote():
     yaml_url = (
-        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
-        "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
+        "https://cdn.jsdelivr.net/gh/PEtab-dev/petab_test_suite"
+        "@main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
     )
 
     validate(yaml_url)

--- a/tests/v2/test_conversion.py
+++ b/tests/v2/test_conversion.py
@@ -33,8 +33,8 @@ def test_v1v2_observable_df_noise_distribution():
 def test_petab1to2_remote():
     """Test that we can upgrade a remote PEtab 1.0.0 problem."""
     yaml_url = (
-        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
-        "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
+        "https://cdn.jsdelivr.net/gh/PEtab-dev/petab_test_suite"
+        "@main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
     )
 
     problem = petab1to2(yaml_url)

--- a/tests/v2/test_core.py
+++ b/tests/v2/test_core.py
@@ -367,8 +367,8 @@ def test_load_remote():
     from jsonschema.exceptions import ValidationError
 
     yaml_url = (
-        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
-        "/main/petabtests/cases/v2.0.0/sbml/0010/_0010.yaml"
+        "https://cdn.jsdelivr.net/gh/PEtab-dev/petab_test_suite"
+        "@main/petabtests/cases/v2.0.0/sbml/0010/_0010.yaml"
     )
 
     try:
@@ -389,8 +389,8 @@ def test_load_remote():
 
 def test_auto_upgrade():
     yaml_url = (
-        "https://raw.githubusercontent.com/PEtab-dev/petab_test_suite"
-        "/main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
+        "https://cdn.jsdelivr.net/gh/PEtab-dev/petab_test_suite"
+        "@main/petabtests/cases/v1.0.0/sbml/0001/_0001.yaml"
     )
     problem = Problem.from_yaml(yaml_url)
     # TODO check something specifically different in a v2 problem


### PR DESCRIPTION
Avoid rate-limiting issues during downloading from raw.githubusercontent.com, use https://www.jsdelivr.com/ instead.

Caveat: It may take up to 12h until branch references are updated there.

Closes #389.