### PR TITLE
Fix ProblemExtensions.sciml defaulting to non-None

### DIFF
--- a/petab/v2/core.py
+++ b/petab/v2/core.py
@@ -316,8 +316,8 @@ from .extensions.sciml import SciMLExt  # noqa: E402
 class ProblemExtensions:
     """Runtime extension state attached to a :class:`Problem`."""
 
-    def __init__(self, sciml: SciMLExt = None):
-        self.sciml: SciMLExt = sciml or SciMLExt()
+    def __init__(self, sciml: SciMLExt | None = None):
+        self.sciml: SciMLExt | None = sciml
 
 
 class Observable(BaseModel):

--- a/tests/v2/test_sciml.py
+++ b/tests/v2/test_sciml.py
@@ -4,11 +4,12 @@ from petab_sciml import Input, Node
 from pydantic import ConfigDict
 
 from petab.v2.core import *
-from petab.v2.core import ModelFile
+from petab.v2.core import ModelFile, ProblemExtensions
 from petab.v2.extensions.sciml import (
     Hybridization,
     NeuralNetConfig,
     SciMLConfig,
+    SciMLExt,
 )
 from petab.v2.extensions.sciml_lint import (
     CheckArrayDataFiles,
@@ -46,7 +47,8 @@ def _get_test_problem():
                     },
                 )
             },
-        )
+        ),
+        extensions=ProblemExtensions(sciml=SciMLExt()),
     )
     problem.model = SbmlModel.from_antimony("""
     model lv
@@ -150,6 +152,15 @@ def _get_test_problem():
     # problem.extensions.sciml.array_data_files[0].rel_path = "net1_ps.hdf5"
 
     return problem
+
+
+def test_extensions_sciml_none_by_default():
+    """`Problem.extensions.sciml` is `None` unless the sciml extension is
+    actually used."""
+    assert Problem().extensions.sciml is None
+
+    problem = _get_test_problem()
+    assert problem.extensions.sciml is not None
 
 
 def test_lint():


### PR DESCRIPTION
Fixes #512.

In some places, `problem.extensions.sciml` was assumed to be `None` for non-sciml problems, but it wasn't. In other places it was assumed to always be a `SciMLExt` instance. I find the former more intuitive and updated the code accordingly.