### PR TITLE
Skip cond ids set by arrays for all periods

### DIFF
--- a/petab/v2/converters.py
+++ b/petab/v2/converters.py
@@ -248,6 +248,12 @@ class ExperimentsToSbmlConverter:
                 #  or the only non-equilibration period (handled above)
                 continue
 
+            # Skip if condition ids are set by array data
+            if self._array_data_condition_ids and set(
+                period.condition_ids
+            ).issubset(self._array_data_condition_ids):
+                continue
+
             # Encode the period changes in the SBML model as events
             #  that trigger at the start of the period or,
             #  for the first period, as initial assignments.
@@ -258,12 +264,6 @@ class ExperimentsToSbmlConverter:
             #  single-period experiments.
             if i_period == 0:
                 exp_ind_id = self.get_experiment_indicator(experiment.id)
-                # Skip if condition ids are set by array data
-                # importers handle this
-                if self._array_data_condition_ids and set(
-                    period.condition_ids
-                ).issubset(self._array_data_condition_ids):
-                    continue
 
                 for change in self._new_problem.get_changes_for_period(period):
                     period0_assignments.setdefault(

--- a/tests/v2/test_sciml.py
+++ b/tests/v2/test_sciml.py
@@ -467,9 +467,9 @@ def test_genuinely_missing_output_parameter_still_reported():
 # Experiment -> SBML conversion
 # ---------------------------------------------------------------------------
 
+
 def test_convert_experiments_with_array_data_condition_ids():
-    """Conditions defined only in array files are skipped in every period.
-    """
+    """Conditions defined only in array files are skipped in every period."""
     from petab.v2.converters import ExperimentsToSbmlConverter
 
     problem = _get_test_problem()

--- a/tests/v2/test_sciml.py
+++ b/tests/v2/test_sciml.py
@@ -464,6 +464,43 @@ def test_genuinely_missing_output_parameter_still_reported():
 
 
 # ---------------------------------------------------------------------------
+# Experiment -> SBML conversion
+# ---------------------------------------------------------------------------
+
+def test_convert_experiments_with_array_data_condition_ids():
+    """Conditions defined only in array files are skipped in every period.
+    """
+    from petab.v2.converters import ExperimentsToSbmlConverter
+
+    problem = _get_test_problem()
+    assert not problem.conditions, "cond1 must not be in the condition table"
+    array_condition_ids = (
+        problem.extensions.sciml._get_array_data_condition_ids()
+    )
+    assert array_condition_ids == {"cond1"}
+
+    # Add preequilibration and simulation periods
+    periods = [(-float("inf"), "cond1"), (0.0, "cond1")]
+    problem.experiments[0].periods = [
+        ExperimentPeriod(time=time, condition_ids=[condition_id])
+        for time, condition_id in periods
+    ]
+
+    converted = ExperimentsToSbmlConverter(problem).convert()
+
+    # No events defined for conditions given by array data
+    sbml_model = converted.model.sbml_model
+    assigned_targets = {
+        ia.getSymbol() for ia in sbml_model.getListOfInitialAssignments()
+    } | {
+        ea.getVariable()
+        for event in sbml_model.getListOfEvents()
+        for ea in event.getListOfEventAssignments()
+    }
+    assert "net1_input2" not in assigned_targets
+
+
+# ---------------------------------------------------------------------------
 # Full-problem integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
PEtab SciML allows condition specific array data.  In this scenario an array must be provided for each condition and the linter checks that all condition ids are set. 

If this is the case, the changes for all periods do not need to be encoded as events and can be skipped. Previously, only changes in the first period were skipped. 